### PR TITLE
Add BTMS architecture comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Research-backed notes and reproducible examples for battery thermal behavior, BT
 ## Starter Notes
 
 - [Battery thermal modeling assumptions](notes/modeling-assumptions.md)
+- [BTMS architecture comparison](notes/btms-architecture-comparison.md)
 - [Battery thermal validation checklist](templates/validation-checklist.md)
 - [Reading log template](references/reading-log-template.md)
 - [Reading log: NREL Li-ion thermal characterization](references/reading-log-nrel-li-ion-thermal-characterization.md)
@@ -40,6 +41,6 @@ LICENSE
 ## Contribution Entry Points
 
 - Add a public reading-log entry.
-- Add a BTMS architecture comparison table.
+- Extend the BTMS architecture comparison with source-backed examples.
 - Add a note on heat generation model selection.
 - Improve validation checklist wording with units and boundary conditions.

--- a/notes/btms-architecture-comparison.md
+++ b/notes/btms-architecture-comparison.md
@@ -1,0 +1,27 @@
+# BTMS Architecture Comparison
+
+Battery thermal management system (BTMS) choices should be compared against the operating profile, packaging constraints, service model, safety concept, and validation evidence available for the project.
+
+## Comparison Table
+
+| Architecture | Strengths | Limitations | Instrumentation / Review Points | Typical Fit |
+|---|---|---|---|---|
+| Air cooling | Simple layout, easier inspection, lower fluid-management burden. | Lower heat-transfer capability, airflow non-uniformity, fan noise and parasitic load. | Air inlet/outlet temperature, cell surface temperature spread, fan command, filter condition. | Low to moderate heat loads, education models, early concept comparison. |
+| Liquid cold plate | Higher heat-transfer capability, compact module integration, controllable flow paths. | More components, leak risk, pump and coolant maintenance, plate-to-cell contact quality matters. | Coolant inlet/outlet temperature, flow rate, pressure drop, leak detection, thermal-interface condition. | EV modules, high-duty stationary systems, tightly packaged battery modules. |
+| Refrigerant / direct cooling | Strong temperature control potential and direct connection to HVAC-style loops. | Higher integration complexity, service requirements, refrigerant safety and controls coordination. | Refrigerant pressure, temperature, compressor command, evaporator distribution, fault states. | High-performance systems where HVAC integration and service capability are available. |
+| Phase-change material | Passive buffering, can reduce short-duration temperature peaks, low moving-part count. | Limited heat rejection without a recovery path, added mass, material aging and containment questions. | Material temperature range, melt/freeze window, containment condition, recovery time between pulses. | Peak buffering, short pulses, supplemental thermal design rather than sole heat rejection. |
+| Hybrid approach | Can combine active heat rejection with passive buffering or targeted cooling. | More interfaces to validate, harder fault analysis, higher controls and documentation burden. | Boundary-condition map, operating mode transitions, sensor coverage, failure-mode evidence. | Systems with variable duty cycles or strict temperature-uniformity targets. |
+
+## Selection Questions
+
+- What current, power, and ambient-temperature profile drives the thermal design case?
+- Is the design trying to limit absolute temperature, temperature gradient, aging rate, or short-term peak temperature?
+- What evidence proves the model boundary conditions match the intended pack or container layout?
+- Which sensors are needed to detect non-uniform cooling, blockage, leakage, or thermal runaway precursors?
+- How will maintenance teams inspect the cooling path without relying on hidden assumptions?
+
+## Source-Friendly Notes
+
+- Treat this as a comparison scaffold, not a final design rule.
+- Replace broad phrases such as "better cooling" with measured quantities: heat-transfer rate, temperature spread, pressure drop, response time, or parasitic load.
+- Tie any project-specific conclusion to a public paper, datasheet, test report, or measured validation dataset before using it in a design review.


### PR DESCRIPTION
## Summary
- add a BTMS architecture comparison table covering air, liquid, refrigerant, phase-change, and hybrid approaches
- link the comparison from the README
- keep claims general and source-friendly for future expansion

Closes #5.

## Validation
- git diff --check