### PR TITLE
Add thermal assumptions example table

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Research-backed notes and reproducible examples for battery thermal behavior, BT
 - [Battery thermal modeling assumptions](notes/modeling-assumptions.md)
 - [BTMS architecture comparison](notes/btms-architecture-comparison.md)
 - [Heat-generation model selection](notes/heat-generation-model-selection.md)
+- [Thermal assumptions example table](notes/thermal-assumptions-example-table.md)
 - [Battery thermal validation checklist](templates/validation-checklist.md)
 - [Reading log template](references/reading-log-template.md)
 - [Reading log: NREL Li-ion thermal characterization](references/reading-log-nrel-li-ion-thermal-characterization.md)
@@ -44,4 +45,5 @@ LICENSE
 - Add a public reading-log entry.
 - Extend the BTMS architecture comparison with source-backed examples.
 - Add source-backed examples to the heat-generation model selection note.
+- Adapt the thermal assumptions example table for a sourced case study.
 - Improve validation checklist wording with units and boundary conditions.

--- a/notes/thermal-assumptions-example-table.md
+++ b/notes/thermal-assumptions-example-table.md
@@ -1,0 +1,29 @@
+# Thermal Assumptions Example Table
+
+Use this table as a compact example for documenting battery thermal model assumptions before sharing plots, simulation results, or design claims.
+
+## Example Assumptions
+
+| Category | Assumption | Placeholder Value | Unit | Why It Matters |
+|---|---|---|---|---|
+| Cell format | Prismatic Li-ion cell | 50 Ah nominal | Ah | Capacity affects C-rate conversion and heat scaling. |
+| Initial SOC | Starting state of charge | 80 | % | SOC can affect open-circuit voltage, resistance, and reversible heat. |
+| Ambient condition | Initial ambient temperature | 25 | degC | Defines starting point for thermal rise and cooling calculations. |
+| Module layout | Cells per module | 12 | cells | Scaling from cell heat to module heat depends on layout. |
+| Cooling mode | Forced air across module face | 2.0 | m/s | Cooling assumption drives surface heat transfer and temperature spread. |
+| Heat source | Lumped ohmic heat estimate | `I^2 * R` | W | Simple placeholder until measured or condition-dependent heat data is available. |
+| Thermal boundary | Convection coefficient | 15 | W/m^2-K | Strongly influences predicted steady-state temperature. |
+| Contact assumption | Cell-to-frame contact resistance | Not modeled | - | Contact assumptions should be stated when gradients matter. |
+| Validation reference | Pulse test or literature benchmark | TBD | - | Results should be tied to test data, datasheet behavior, or public literature. |
+
+## Review Prompts
+
+- Are units stated for every value that enters a calculation?
+- Are SOC, C-rate, and ambient ranges aligned with the intended duty cycle?
+- Is the heat source measured, fitted, estimated from resistance, or marked as a placeholder?
+- Does the cooling boundary reflect the actual module or pack arrangement?
+- Are excluded effects documented, such as interconnect heat, contact resistance, or aging?
+
+## Reuse Note
+
+Treat the placeholder values as examples only. Replace them with project, datasheet, lab, or literature-backed assumptions before using the table in a design review.


### PR DESCRIPTION
## Summary
- add a thermal assumptions example table under notes
- include placeholder cell, module, ambient, cooling, and heat-source assumptions with units
- link the note from the README

Closes #11.

## Validation
- git diff --check