### PR TITLE
Add thermal source confidence guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Research-backed notes and reproducible examples for battery thermal behavior, BT
 - [BTMS architecture comparison](notes/btms-architecture-comparison.md)
 - [Heat-generation model selection](notes/heat-generation-model-selection.md)
 - [Thermal model limitations](notes/thermal-model-limitations.md)
+- [Thermal source confidence guide](notes/thermal-source-confidence-guide.md)
 - [Thermal assumptions example table](notes/thermal-assumptions-example-table.md)
 - [Thermal validation example result summary](notes/thermal-validation-example-result-summary.md)
 - [Battery thermal validation checklist](templates/validation-checklist.md)
@@ -49,6 +50,7 @@ LICENSE
 - Extend the BTMS architecture comparison with source-backed examples.
 - Add source-backed examples to the heat-generation model selection note.
 - Add mitigation examples to the thermal model limitations note.
+- Add source ranking examples to the thermal source confidence guide.
 - Adapt the thermal assumptions example table for a sourced case study.
 - Replace the thermal validation example summary with a sourced case study.
 - Add source-backed BTMS claim examples to the BTMS source checklist.

--- a/notes/thermal-source-confidence-guide.md
+++ b/notes/thermal-source-confidence-guide.md
@@ -1,0 +1,25 @@
+# Thermal Source Confidence Guide
+
+Use this guide to rank confidence in battery thermal sources before using them to support a BTMS claim, validation result, or modeling assumption.
+
+| Source Type | Typical Confidence | Useful For | Main Risk |
+|---|---|---|---|
+| Measured dataset | High | Validation, parameter fitting, condition-aware heat generation. | May not match the project cell, age, SOC, or thermal boundary. |
+| Test report | High to medium | Design review and acceptance evidence when conditions are documented. | Test setup may not cover the full operating envelope. |
+| Peer-reviewed paper | Medium | Explaining methods, trends, and public assumptions. | Cell chemistry, geometry, and duty cycle may differ from the project. |
+| Datasheet | Medium to low | Initial limits, capacity, resistance ranges, and rough assumptions. | Often lacks heat-generation detail and operating-condition context. |
+| Simulation-only evidence | Low | Early screening, sensitivity studies, and education. | Can look precise while relying on unvalidated inputs. |
+
+## Confidence Ranking
+
+| Rank | Evidence Standard | Review Question |
+|---|---|---|
+| 5 | Measured project-relevant dataset | Does it cover the same cell/module, C-rate, SOC, ambient, and cooling condition? |
+| 4 | Controlled test report | Are setup, instruments, units, and boundary conditions traceable? |
+| 3 | Public paper or benchmark | Is the method relevant even if the hardware is different? |
+| 2 | Datasheet or supplier summary | Which assumptions are stated, and which are missing? |
+| 1 | Simulation-only placeholder | Is it clearly marked as screening-level evidence? |
+
+## Review Rule
+
+Confidence should come from operating-condition match, measurement quality, and traceability. A source is not high confidence simply because it is technical or published.


### PR DESCRIPTION
## Summary
- add a thermal source confidence guide
- compare measured datasets, test reports, papers, datasheets, and simulation-only evidence
- link the guide from the README

Closes #19.

## Validation
- git diff --check