### PR TITLE
Add thermal validation decision log

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Research-backed notes and reproducible examples for battery thermal behavior, BT
 - [Thermal validation example result summary](notes/thermal-validation-example-result-summary.md)
 - [Battery thermal validation checklist](templates/validation-checklist.md)
 - [BTMS source checklist](templates/btms-source-checklist.md)
+- [Thermal validation decision log](templates/thermal-validation-decision-log.md)
 - [Reading log template](references/reading-log-template.md)
 - [Reading log: NREL Li-ion thermal characterization](references/reading-log-nrel-li-ion-thermal-characterization.md)
 
@@ -55,3 +56,4 @@ LICENSE
 - Replace the thermal validation example summary with a sourced case study.
 - Add source-backed BTMS claim examples to the BTMS source checklist.
 - Improve validation checklist wording with units and boundary conditions.
+- Add real project decisions to the thermal validation decision log.

--- a/templates/thermal-validation-decision-log.md
+++ b/templates/thermal-validation-decision-log.md
@@ -1,0 +1,16 @@
+# Thermal Validation Decision Log
+
+Use this log to capture thermal modeling assumptions, validation choices, and evidence decisions before results are shared or reused.
+
+| Decision ID | Decision | Rationale | Source | Owner | Date | Impact |
+|---|---|---|---|---|---|---|
+| TVD-001 | Define cell-level or pack-level validation boundary | Clarifies whether temperature error is being judged at the cell, module, or enclosure level | Test plan or public dataset | Thermal lead | TBD | Prevents mismatched validation claims |
+| TVD-002 | Select heat-generation model for the current operating range | Ensures the model complexity matches available parameters and evidence | Literature note or experiment | Modeling owner | TBD | Controls uncertainty in loss estimates |
+| TVD-003 | Record accepted error threshold and units | Makes pass/fail interpretation reviewable | Validation checklist | Reviewer | TBD | Keeps comparisons consistent across revisions |
+
+## Decision Review Prompts
+
+- What assumption would change the validation result the most?
+- Is the evidence source measured data, supplier data, literature, or an engineering estimate?
+- Does the decision affect safety margin, lifetime estimate, cooling selection, or only presentation?
+- Who can approve changing the decision after the result is shared?


### PR DESCRIPTION
## Summary
- Add a thermal validation decision log for assumptions, validation choices, and evidence decisions.
- Link the log from the README starter notes and contribution entry points.

Closes #21

## Validation
- git diff --check