### PR TITLE
Add thermal parameter traceability matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Research-backed notes and reproducible examples for battery thermal behavior, BT
 - [Battery thermal validation checklist](templates/validation-checklist.md)
 - [BTMS source checklist](templates/btms-source-checklist.md)
 - [Thermal validation decision log](templates/thermal-validation-decision-log.md)
+- [Thermal parameter traceability matrix](templates/thermal-parameter-traceability-matrix.md)
 - [Reading log template](references/reading-log-template.md)
 - [Reading log: NREL Li-ion thermal characterization](references/reading-log-nrel-li-ion-thermal-characterization.md)
 
@@ -57,3 +58,4 @@ LICENSE
 - Add source-backed BTMS claim examples to the BTMS source checklist.
 - Improve validation checklist wording with units and boundary conditions.
 - Add real project decisions to the thermal validation decision log.
+- Add project-specific examples to the thermal parameter traceability matrix.

--- a/templates/thermal-parameter-traceability-matrix.md
+++ b/templates/thermal-parameter-traceability-matrix.md
@@ -1,0 +1,18 @@
+# Thermal Parameter Traceability Matrix
+
+Use this matrix to track where thermal parameters came from and how they affect validation confidence.
+
+| Parameter | Unit | Source | Reference Condition | Validation Impact | Owner |
+|---|---|---|---|---|---|
+| Cell heat capacity | J/K or J/kg-K | Test data, supplier data, or literature | Temperature range and SOC window | High if transient temperature rise is compared | Modeling owner |
+| Thermal conductivity | W/m-K | Material datasheet or measured estimate | Direction and compression state | Medium to high for spatial gradients | Thermal lead |
+| Convective coefficient | W/m2-K | Test correlation, CFD, or estimate | Air or coolant flow condition | High for cooling-system comparisons | Reviewer |
+| Internal resistance | ohm | Pulse test, datasheet, or model fit | SOC, temperature, and C-rate | High for heat-generation estimates | Battery engineer |
+| Ambient temperature | degC | Test log or scenario assumption | Test chamber, room, or field condition | Medium for boundary sensitivity | Validation owner |
+
+## Review Prompts
+
+- Which parameter has the weakest source but the largest effect on the result?
+- Are units and reference conditions written close enough to prevent reuse mistakes?
+- Which values are educational placeholders rather than validated project values?
+- Who can approve changing the parameter after a validation result is published?


### PR DESCRIPTION
## Summary
- Add a thermal parameter traceability matrix for thermal parameters, units, sources, reference conditions, validation impact, and ownership.
- Link the matrix from the README starter notes and contribution entry points.

Closes #23

## Validation
- git diff --check
