### PR TITLE
Add cooling loop assumption register

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Research-backed notes and reproducible examples for battery thermal behavior, BT
 - [Reading log template](references/reading-log-template.md)
 - [Reading log: NREL Li-ion thermal characterization](references/reading-log-nrel-li-ion-thermal-characterization.md)
 
+- [Cooling Loop Assumption Register](templates/cooling-loop-assumption-register.md)
+
 ## Repository Topics
 
 ```text
@@ -59,3 +61,4 @@ LICENSE
 - Improve validation checklist wording with units and boundary conditions.
 - Add real project decisions to the thermal validation decision log.
 - Add project-specific examples to the thermal parameter traceability matrix.
+- Add project-specific examples to the cooling loop assumption register.

--- a/templates/cooling-loop-assumption-register.md
+++ b/templates/cooling-loop-assumption-register.md
@@ -1,0 +1,18 @@
+# Cooling Loop Assumption Register
+
+Use this page for capturing coolant, flow, pressure-drop, and heat-exchanger assumptions before analysis reuse. It helps keep battery thermal modeling notes explicit about sources, assumptions, limits, and validation impact.
+
+| Review Area | Prompt | Evidence Or Decision |
+|---|---|---|
+| Boundary | What cell, module, pack, or cooling scope is being discussed? | Define the physical and analytical boundary. |
+| Source | Which measured data, literature, supplier value, or estimate supports the item? | Link the source or mark it as TBD. |
+| Units | Are units and reference conditions stated clearly? | Include temperature, flow, time, geometry, and operating point when relevant. |
+| Sensitivity | Would changing this assumption alter the conclusion? | Mark high, medium, or low impact. |
+| Validation | How should the assumption be checked before reuse? | Name the comparison, metric, or reviewer. |
+
+## Review Prompts
+
+- What would make this assumption invalid for a different cell, pack, or duty cycle?
+- Is the evidence strong enough for design work, or only for an educational note?
+- Which uncertainty should be called out before sharing results?
+- Who can approve changing the assumption after validation?


### PR DESCRIPTION
## Summary
- Add Cooling Loop Assumption Register for capturing coolant, flow, pressure-drop, and heat-exchanger assumptions before analysis reuse.
- Link the artifact from the repository index.

Closes #25

## Validation
- git diff --check
