### PR TITLE
Add cell to pack scaling note

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Research-backed notes and reproducible examples for battery thermal behavior, BT
 
 - [Thermal Test Data Quality Checklist](templates/thermal-test-data-quality-checklist.md)
 
+- [Cell To Pack Scaling Note](notes/cell-to-pack-scaling-note.md)
+
 ## Repository Topics
 
 ```text
@@ -65,3 +67,4 @@ LICENSE
 - Add project-specific examples to the thermal parameter traceability matrix.
 - Add project-specific examples to the cooling loop assumption register.
 - Add project-specific examples to the thermal test data quality checklist.
+- Add project-specific examples to the cell to pack scaling note.

--- a/notes/cell-to-pack-scaling-note.md
+++ b/notes/cell-to-pack-scaling-note.md
@@ -1,0 +1,18 @@
+# Cell To Pack Scaling Note
+
+Use this page for recording the assumptions used when cell-level thermal behavior is scaled to module or pack level. It helps keep battery thermal modeling notes explicit about sources, assumptions, limits, and validation impact.
+
+| Review Area | Prompt | Evidence Or Decision |
+|---|---|---|
+| Boundary | What cell, module, pack, or cooling scope is being discussed? | Define the physical and analytical boundary. |
+| Source | Which measured data, literature, supplier value, or estimate supports the item? | Link the source or mark it as TBD. |
+| Units | Are units and reference conditions stated clearly? | Include temperature, flow, time, geometry, and operating point when relevant. |
+| Sensitivity | Would changing this assumption alter the conclusion? | Mark high, medium, or low impact. |
+| Validation | How should the assumption be checked before reuse? | Name the comparison, metric, or reviewer. |
+
+## Review Prompts
+
+- What would make this assumption invalid for a different cell, pack, or duty cycle?
+- Is the evidence strong enough for design work, or only for an educational note?
+- Which uncertainty should be called out before sharing results?
+- Who can approve changing the assumption after validation?


### PR DESCRIPTION
## Summary
- Add Cell To Pack Scaling Note for recording the assumptions used when cell-level thermal behavior is scaled to module or pack level.
- Link the artifact from the repository index.

Closes #29

## Validation
- git diff --check
