### PR TITLE
Add thermal runaway scope boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Research-backed notes and reproducible examples for battery thermal behavior, BT
 
 - [Sensor Placement Review Template](templates/sensor-placement-review-template.md)
 
+- [Thermal Runaway Scope Boundary](notes/thermal-runaway-scope-boundary.md)
+
 ## Repository Topics
 
 ```text
@@ -74,3 +76,4 @@ LICENSE
 - Add project-specific examples to the cell to pack scaling note.
 - Add project-specific examples to the ambient boundary condition log.
 - Add project-specific examples to the sensor placement review template.
+- Add project-specific examples to the thermal runaway scope boundary.

--- a/notes/thermal-runaway-scope-boundary.md
+++ b/notes/thermal-runaway-scope-boundary.md
@@ -1,0 +1,18 @@
+# Thermal Runaway Scope Boundary
+
+Use this page for stating what thermal runaway topics are inside or outside a modeling note or analysis. It helps keep battery thermal modeling notes explicit about sources, assumptions, limits, and validation impact.
+
+| Review Area | Prompt | Evidence Or Decision |
+|---|---|---|
+| Boundary | What cell, module, pack, or cooling scope is being discussed? | Define the physical and analytical boundary. |
+| Source | Which measured data, literature, supplier value, or estimate supports the item? | Link the source or mark it as TBD. |
+| Units | Are units and reference conditions stated clearly? | Include temperature, flow, time, geometry, and operating point when relevant. |
+| Sensitivity | Would changing this assumption alter the conclusion? | Mark high, medium, or low impact. |
+| Validation | How should the assumption be checked before reuse? | Name the comparison, metric, or reviewer. |
+
+## Review Prompts
+
+- What would make this assumption invalid for a different cell, pack, or duty cycle?
+- Is the evidence strong enough for design work, or only for an educational note?
+- Which uncertainty should be called out before sharing results?
+- Who can approve changing the assumption after validation?


### PR DESCRIPTION
## Summary
- Add Thermal Runaway Scope Boundary for stating what thermal runaway topics are inside or outside a modeling note or analysis.
- Link the artifact from the repository index.

Closes #35

## Validation
- git diff --check
