### PR TITLE
Add heat rejection pathway map

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Research-backed notes and reproducible examples for battery thermal behavior, BT
 
 - [BTMS Control Assumption Table](templates/btms-control-assumption-table.md)
 
+- [Heat Rejection Pathway Map](notes/heat-rejection-pathway-map.md)
+
 ## Repository Topics
 
 ```text
@@ -80,3 +82,4 @@ LICENSE
 - Add project-specific examples to the sensor placement review template.
 - Add project-specific examples to the thermal runaway scope boundary.
 - Add project-specific examples to the btms control assumption table.
+- Add project-specific examples to the heat rejection pathway map.

--- a/notes/heat-rejection-pathway-map.md
+++ b/notes/heat-rejection-pathway-map.md
@@ -1,0 +1,18 @@
+# Heat Rejection Pathway Map
+
+Use this page for mapping the path from cell heat generation to the final heat sink in thermal notes. It helps keep battery thermal modeling notes explicit about sources, assumptions, limits, and validation impact.
+
+| Review Area | Prompt | Evidence Or Decision |
+|---|---|---|
+| Boundary | What cell, module, pack, or cooling scope is being discussed? | Define the physical and analytical boundary. |
+| Source | Which measured data, literature, supplier value, or estimate supports the item? | Link the source or mark it as TBD. |
+| Units | Are units and reference conditions stated clearly? | Include temperature, flow, time, geometry, and operating point when relevant. |
+| Sensitivity | Would changing this assumption alter the conclusion? | Mark high, medium, or low impact. |
+| Validation | How should the assumption be checked before reuse? | Name the comparison, metric, or reviewer. |
+
+## Review Prompts
+
+- What would make this assumption invalid for a different cell, pack, or duty cycle?
+- Is the evidence strong enough for design work, or only for an educational note?
+- Which uncertainty should be called out before sharing results?
+- Who can approve changing the assumption after validation?


### PR DESCRIPTION
## Summary
- Add Heat Rejection Pathway Map for mapping the path from cell heat generation to the final heat sink in thermal notes.
- Link the artifact from the repository index.

Closes #39

## Validation
- git diff --check
