### PR TITLE
Add literature claim extraction template

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Research-backed notes and reproducible examples for battery thermal behavior, BT
 
 - [Uncertainty Review Checklist](templates/uncertainty-review-checklist.md)
 
+- [Literature Claim Extraction Template](references/literature-claim-extraction-template.md)
+
 ## Repository Topics
 
 ```text
@@ -89,3 +91,4 @@ LICENSE
 - Add project-specific examples to the heat rejection pathway map.
 - Add project-specific examples to the validation metric selection guide.
 - Add project-specific examples to the uncertainty review checklist.
+- Add project-specific examples to the literature claim extraction template.

--- a/references/literature-claim-extraction-template.md
+++ b/references/literature-claim-extraction-template.md
@@ -1,0 +1,18 @@
+# Literature Claim Extraction Template
+
+Use this page for extracting source-backed thermal claims from public literature without losing context. It helps keep battery thermal modeling notes explicit about sources, assumptions, limits, and validation impact.
+
+| Review Area | Prompt | Evidence Or Decision |
+|---|---|---|
+| Boundary | What cell, module, pack, or cooling scope is being discussed? | Define the physical and analytical boundary. |
+| Source | Which measured data, literature, supplier value, or estimate supports the item? | Link the source or mark it as TBD. |
+| Units | Are units and reference conditions stated clearly? | Include temperature, flow, time, geometry, and operating point when relevant. |
+| Sensitivity | Would changing this assumption alter the conclusion? | Mark high, medium, or low impact. |
+| Validation | How should the assumption be checked before reuse? | Name the comparison, metric, or reviewer. |
+
+## Review Prompts
+
+- What would make this assumption invalid for a different cell, pack, or duty cycle?
+- Is the evidence strong enough for design work, or only for an educational note?
+- Which uncertainty should be called out before sharing results?
+- Who can approve changing the assumption after validation?


### PR DESCRIPTION
## Summary
- Add Literature Claim Extraction Template for extracting source-backed thermal claims from public literature without losing context.
- Link the artifact from the repository index.

Closes #45

## Validation
- git diff --check
