### PR TITLE
Add material property source register

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Research-backed notes and reproducible examples for battery thermal behavior, BT
 
 - [Thermal Model Change Log](templates/thermal-model-change-log.md)
 
+- [Material Property Source Register](templates/material-property-source-register.md)
+
 ## Repository Topics
 
 ```text
@@ -98,3 +100,4 @@ LICENSE
 - Add project-specific examples to the literature claim extraction template.
 - Add project-specific examples to the experimental condition comparison.
 - Add project-specific examples to the thermal model change log.
+- Add project-specific examples to the material property source register.

--- a/templates/material-property-source-register.md
+++ b/templates/material-property-source-register.md
@@ -1,0 +1,18 @@
+# Material Property Source Register
+
+Use this page for tracking density, heat capacity, conductivity, and other material-property sources. It helps keep battery thermal modeling notes explicit about sources, assumptions, limits, and validation impact.
+
+| Review Area | Prompt | Evidence Or Decision |
+|---|---|---|
+| Boundary | What cell, module, pack, or cooling scope is being discussed? | Define the physical and analytical boundary. |
+| Source | Which measured data, literature, supplier value, or estimate supports the item? | Link the source or mark it as TBD. |
+| Units | Are units and reference conditions stated clearly? | Include temperature, flow, time, geometry, and operating point when relevant. |
+| Sensitivity | Would changing this assumption alter the conclusion? | Mark high, medium, or low impact. |
+| Validation | How should the assumption be checked before reuse? | Name the comparison, metric, or reviewer. |
+
+## Review Prompts
+
+- What would make this assumption invalid for a different cell, pack, or duty cycle?
+- Is the evidence strong enough for design work, or only for an educational note?
+- Which uncertainty should be called out before sharing results?
+- Who can approve changing the assumption after validation?


### PR DESCRIPTION
## Summary
- Add Material Property Source Register for tracking density, heat capacity, conductivity, and other material-property sources.
- Link the artifact from the repository index.

Closes #51

## Validation
- git diff --check
