### PR TITLE
Add cooling strategy trade study

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Research-backed notes and reproducible examples for battery thermal behavior, BT
 
 - [Transient Vs Steady State Guide](notes/transient-vs-steady-state-guide.md)
 
+- [Cooling Strategy Trade Study](notes/cooling-strategy-trade-study.md)
+
 ## Repository Topics
 
 ```text
@@ -104,3 +106,4 @@ LICENSE
 - Add project-specific examples to the thermal model change log.
 - Add project-specific examples to the material property source register.
 - Add project-specific examples to the transient vs steady state guide.
+- Add project-specific examples to the cooling strategy trade study.

--- a/notes/cooling-strategy-trade-study.md
+++ b/notes/cooling-strategy-trade-study.md
@@ -1,0 +1,18 @@
+# Cooling Strategy Trade Study
+
+Use this page for comparing passive, air, liquid, and hybrid thermal management options at concept level. It helps keep battery thermal modeling notes explicit about sources, assumptions, limits, and validation impact.
+
+| Review Area | Prompt | Evidence Or Decision |
+|---|---|---|
+| Boundary | What cell, module, pack, or cooling scope is being discussed? | Define the physical and analytical boundary. |
+| Source | Which measured data, literature, supplier value, or estimate supports the item? | Link the source or mark it as TBD. |
+| Units | Are units and reference conditions stated clearly? | Include temperature, flow, time, geometry, and operating point when relevant. |
+| Sensitivity | Would changing this assumption alter the conclusion? | Mark high, medium, or low impact. |
+| Validation | How should the assumption be checked before reuse? | Name the comparison, metric, or reviewer. |
+
+## Review Prompts
+
+- What would make this assumption invalid for a different cell, pack, or duty cycle?
+- Is the evidence strong enough for design work, or only for an educational note?
+- Which uncertainty should be called out before sharing results?
+- Who can approve changing the assumption after validation?


### PR DESCRIPTION
## Summary
- Add Cooling Strategy Trade Study for comparing passive, air, liquid, and hybrid thermal management options at concept level.
- Link the artifact from the repository index.

Closes #55

## Validation
- git diff --check
