### PR TITLE
Add executable lumped thermal model

### DIFF
--- a/.github/workflows/markdown-maintenance.yml
+++ b/.github/workflows/markdown-maintenance.yml
@@ -1,23 +1,40 @@
-name: Markdown maintenance
+name: Model and Markdown validation
 
 on:
   workflow_dispatch:
   pull_request:
     paths:
       - "**.md"
+      - "**.py"
+      - ".github/workflows/markdown-maintenance.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "**.md"
+      - "**.py"
+      - ".github/workflows/markdown-maintenance.yml"
 
 permissions:
   contents: read
 
 jobs:
-  link-check:
+  validate:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Test executable models
+        run: python -m unittest discover -s tests -v
 
       - name: Check Markdown links
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --verbose --no-progress README.md CONTRIBUTING.md notes/*.md templates/*.md references/*.md
+          args: --verbose --no-progress README.md CONTRIBUTING.md models/*.md notes/*.md templates/*.md references/*.md
           fail: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,7 @@
 # Contributing
 
-Contributions should make battery thermal modeling clearer, more reproducible, or easier to validate.
+Contributions should make battery thermal modeling clearer, more reproducible,
+or easier to validate.
 
 ## Good Contributions
 
@@ -15,3 +16,4 @@ Contributions should make battery thermal modeling clearer, more reproducible, o
 - [ ] Units are explicit.
 - [ ] Assumptions are stated.
 - [ ] No copyrighted paper text is copied.
+- [ ] `python -m unittest discover -s tests -v` passes for model changes.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Battery Thermal Modeling Notes
 
-[![Markdown maintenance](https://github.com/mohammadrezwankhan/battery-thermal-modeling-notes/actions/workflows/markdown-maintenance.yml/badge.svg)](https://github.com/mohammadrezwankhan/battery-thermal-modeling-notes/actions/workflows/markdown-maintenance.yml)
+[![Model and Markdown validation](https://github.com/mohammadrezwankhan/battery-thermal-modeling-notes/actions/workflows/markdown-maintenance.yml/badge.svg)](https://github.com/mohammadrezwankhan/battery-thermal-modeling-notes/actions/workflows/markdown-maintenance.yml)
 
-Research-backed notes and reproducible examples for battery thermal behavior, BTMS design thinking, and validation assumptions.
+Research-backed notes and reproducible examples for battery thermal behavior,
+BTMS design thinking, and validation assumptions.
 
 ## Focus Areas
 
@@ -13,6 +14,8 @@ Research-backed notes and reproducible examples for battery thermal behavior, BT
 - Reading notes from public literature.
 
 ## Starter Notes
+
+- [Executable lumped cell thermal reference](models/README.md)
 
 - [Battery thermal modeling assumptions](notes/modeling-assumptions.md)
 - [BTMS architecture comparison](notes/btms-architecture-comparison.md)
@@ -71,7 +74,8 @@ Research-backed notes and reproducible examples for battery thermal behavior, BT
 ## Repository Topics
 
 ```text
-battery thermal-management btms bms electric-vehicles matlab simulink research-notes battery-modeling
+battery thermal-management btms bms electric-vehicles matlab simulink
+research-notes battery-modeling
 ```
 
 ## Suggested Structure
@@ -85,6 +89,19 @@ README.md
 CONTRIBUTING.md
 LICENSE
 ```
+
+## Run The Executable Reference
+
+The dependency-free lumped model implements irreversible `I^2 R` heating,
+linear heat rejection, and a discrete energy-balance diagnostic:
+
+```powershell
+python models/lumped_cell_thermal.py --current-a 75 --duration-s 600
+python -m unittest discover -s tests -v
+```
+
+See the [model assumptions and limitations](models/README.md) before adapting
+the parameters or using the output in an engineering review.
 
 ## Contribution Entry Points
 

--- a/models/README.md
+++ b/models/README.md
@@ -1,0 +1,53 @@
+# Lumped Cell Thermal Reference
+
+This dependency-free Python model turns the repository's simplest documented
+thermal assumptions into an executable calculation. It is intended for
+education, early screening, and validation-workflow examples, not cell design
+or safety qualification.
+
+## Governing Balance
+
+For each time interval, the model evaluates:
+
+```text
+Q_generation = I^2 R
+Q_rejection = h (T_cell - T_ambient)
+C_thermal dT/dt = Q_generation - Q_rejection
+C_thermal = mass * specific_heat
+```
+
+The temperature state is advanced with an explicit Euler step. The returned
+result includes stored thermal energy, integrated net heat, and their absolute
+difference so discretization and implementation changes can be audited.
+
+## Run The Reference Case
+
+From the repository root with Python 3.12 or later:
+
+```powershell
+python models/lumped_cell_thermal.py `
+  --current-a 75 `
+  --duration-s 600 `
+  --time-step-s 1
+```
+
+The default case represents a 75 A constant-current interval applied to a
+1.05 kg lumped cell with 1000 J/(kg K) specific heat, 4 mOhm resistance,
+1.2 W/K heat transfer, and 25 degC initial and ambient temperature.
+
+Run the regression checks with:
+
+```powershell
+python -m unittest discover -s tests -v
+```
+
+## Explicit Limitations
+
+- Resistance is constant and does not vary with SOC, temperature, or age.
+- Heat generation contains irreversible ohmic loss only.
+- Reversible entropic heat is excluded.
+- The cell is represented by one uniform temperature state.
+- Heat transfer is linear and ambient temperature is fixed.
+- Electrical SOC and voltage dynamics are outside this reference model.
+- Parameters are educational placeholders and require sourced replacement for
+  engineering decisions.

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,0 +1,1 @@
+"""Executable reference models for the battery thermal notes."""

--- a/models/lumped_cell_thermal.py
+++ b/models/lumped_cell_thermal.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import argparse
+import math
+from dataclasses import dataclass
+from typing import Sequence
+
+
+@dataclass(frozen=True)
+class LumpedThermalSpec:
+    """Parameters for a one-node cell thermal model."""
+
+    mass_kg: float = 1.05
+    specific_heat_j_per_kg_k: float = 1000.0
+    resistance_ohm: float = 0.004
+    heat_transfer_w_per_k: float = 1.2
+    ambient_temperature_c: float = 25.0
+    initial_temperature_c: float = 25.0
+    time_step_s: float = 1.0
+
+    @property
+    def thermal_capacity_j_per_k(self) -> float:
+        return self.mass_kg * self.specific_heat_j_per_kg_k
+
+    def validate(self) -> None:
+        finite_values = {
+            "mass_kg": self.mass_kg,
+            "specific_heat_j_per_kg_k": self.specific_heat_j_per_kg_k,
+            "resistance_ohm": self.resistance_ohm,
+            "heat_transfer_w_per_k": self.heat_transfer_w_per_k,
+            "ambient_temperature_c": self.ambient_temperature_c,
+            "initial_temperature_c": self.initial_temperature_c,
+            "time_step_s": self.time_step_s,
+        }
+        for name, value in finite_values.items():
+            if not math.isfinite(value):
+                raise ValueError(f"{name} must be finite")
+
+        if self.mass_kg <= 0.0:
+            raise ValueError("mass_kg must be positive")
+        if self.specific_heat_j_per_kg_k <= 0.0:
+            raise ValueError("specific_heat_j_per_kg_k must be positive")
+        if self.resistance_ohm < 0.0:
+            raise ValueError("resistance_ohm must be nonnegative")
+        if self.heat_transfer_w_per_k < 0.0:
+            raise ValueError("heat_transfer_w_per_k must be nonnegative")
+        if self.time_step_s <= 0.0:
+            raise ValueError("time_step_s must be positive")
+
+
+@dataclass(frozen=True)
+class ThermalSimulation:
+    """Discrete temperatures and interval-level heat flows."""
+
+    time_s: tuple[float, ...]
+    temperature_c: tuple[float, ...]
+    current_a: tuple[float, ...]
+    heat_generation_w: tuple[float, ...]
+    heat_rejection_w: tuple[float, ...]
+    thermal_capacity_j_per_k: float
+    time_step_s: float
+
+    @property
+    def peak_temperature_c(self) -> float:
+        return max(self.temperature_c)
+
+    @property
+    def stored_energy_change_j(self) -> float:
+        return self.thermal_capacity_j_per_k * (
+            self.temperature_c[-1] - self.temperature_c[0]
+        )
+
+    @property
+    def integrated_net_heat_j(self) -> float:
+        return sum(
+            (generated - rejected) * self.time_step_s
+            for generated, rejected in zip(
+                self.heat_generation_w,
+                self.heat_rejection_w,
+                strict=True,
+            )
+        )
+
+    @property
+    def energy_balance_error_j(self) -> float:
+        return abs(self.stored_energy_change_j - self.integrated_net_heat_j)
+
+
+def simulate_lumped_temperature(
+    currents_a: Sequence[float],
+    spec: LumpedThermalSpec = LumpedThermalSpec(),
+) -> ThermalSimulation:
+    """Integrate a one-node thermal balance with explicit Euler steps."""
+
+    spec.validate()
+    currents = tuple(float(current) for current in currents_a)
+    if not currents:
+        raise ValueError("currents_a must contain at least one interval")
+    if any(not math.isfinite(current) for current in currents):
+        raise ValueError("all current values must be finite")
+
+    temperatures = [spec.initial_temperature_c]
+    generated_heat: list[float] = []
+    rejected_heat: list[float] = []
+
+    for current in currents:
+        temperature = temperatures[-1]
+        generation_w = current * current * spec.resistance_ohm
+        rejection_w = spec.heat_transfer_w_per_k * (
+            temperature - spec.ambient_temperature_c
+        )
+        temperature_change_c = (
+            (generation_w - rejection_w)
+            * spec.time_step_s
+            / spec.thermal_capacity_j_per_k
+        )
+
+        generated_heat.append(generation_w)
+        rejected_heat.append(rejection_w)
+        temperatures.append(temperature + temperature_change_c)
+
+    times = tuple(index * spec.time_step_s for index in range(len(currents) + 1))
+    return ThermalSimulation(
+        time_s=times,
+        temperature_c=tuple(temperatures),
+        current_a=currents,
+        heat_generation_w=tuple(generated_heat),
+        heat_rejection_w=tuple(rejected_heat),
+        thermal_capacity_j_per_k=spec.thermal_capacity_j_per_k,
+        time_step_s=spec.time_step_s,
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run a constant-current lumped cell thermal calculation."
+    )
+    parser.add_argument("--current-a", type=float, default=75.0)
+    parser.add_argument("--duration-s", type=float, default=600.0)
+    parser.add_argument("--time-step-s", type=float, default=1.0)
+    parser.add_argument("--resistance-ohm", type=float, default=0.004)
+    parser.add_argument("--heat-transfer-w-per-k", type=float, default=1.2)
+    parser.add_argument("--ambient-temperature-c", type=float, default=25.0)
+    parser.add_argument("--initial-temperature-c", type=float, default=25.0)
+    parser.add_argument("--mass-kg", type=float, default=1.05)
+    parser.add_argument("--specific-heat-j-per-kg-k", type=float, default=1000.0)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.duration_s <= 0.0:
+        raise ValueError("duration_s must be positive")
+    if args.time_step_s <= 0.0:
+        raise ValueError("time_step_s must be positive")
+
+    intervals = round(args.duration_s / args.time_step_s)
+    if intervals < 1 or not math.isclose(
+        intervals * args.time_step_s,
+        args.duration_s,
+        rel_tol=0.0,
+        abs_tol=1e-9,
+    ):
+        raise ValueError("duration_s must be an integer multiple of time_step_s")
+
+    spec = LumpedThermalSpec(
+        mass_kg=args.mass_kg,
+        specific_heat_j_per_kg_k=args.specific_heat_j_per_kg_k,
+        resistance_ohm=args.resistance_ohm,
+        heat_transfer_w_per_k=args.heat_transfer_w_per_k,
+        ambient_temperature_c=args.ambient_temperature_c,
+        initial_temperature_c=args.initial_temperature_c,
+        time_step_s=args.time_step_s,
+    )
+    result = simulate_lumped_temperature([args.current_a] * intervals, spec)
+
+    print(f"Intervals: {intervals}")
+    print(f"Final temperature: {result.temperature_c[-1]:.3f} degC")
+    print(f"Peak temperature: {result.peak_temperature_c:.3f} degC")
+    print(f"Stored thermal energy: {result.stored_energy_change_j:.3f} J")
+    print(f"Integrated net heat: {result.integrated_net_heat_j:.3f} J")
+    print(f"Energy-balance error: {result.energy_balance_error_j:.6e} J")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_lumped_cell_thermal.py
+++ b/tests/test_lumped_cell_thermal.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import math
+import unittest
+
+from models.lumped_cell_thermal import (
+    LumpedThermalSpec,
+    simulate_lumped_temperature,
+)
+
+
+class LumpedCellThermalTests(unittest.TestCase):
+    def test_zero_current_stays_at_ambient_equilibrium(self):
+        result = simulate_lumped_temperature([0.0] * 120)
+        self.assertTrue(all(value == 25.0 for value in result.temperature_c))
+        self.assertEqual(result.energy_balance_error_j, 0.0)
+
+    def test_constant_current_matches_discrete_solution(self):
+        spec = LumpedThermalSpec()
+        intervals = 600
+        current_a = 75.0
+        result = simulate_lumped_temperature([current_a] * intervals, spec)
+
+        steady_rise_c = (
+            current_a * current_a * spec.resistance_ohm
+            / spec.heat_transfer_w_per_k
+        )
+        decay = 1.0 - (
+            spec.heat_transfer_w_per_k
+            * spec.time_step_s
+            / spec.thermal_capacity_j_per_k
+        )
+        expected_c = spec.ambient_temperature_c + steady_rise_c * (
+            1.0 - decay**intervals
+        )
+        self.assertAlmostEqual(result.temperature_c[-1], expected_c, places=10)
+        self.assertGreater(result.temperature_c[-1], spec.ambient_temperature_c)
+        self.assertLess(
+            result.temperature_c[-1],
+            spec.ambient_temperature_c + steady_rise_c,
+        )
+
+    def test_discrete_energy_balance_closes(self):
+        profile = [80.0] * 300 + [0.0] * 300
+        result = simulate_lumped_temperature(profile)
+        self.assertLess(result.energy_balance_error_j, 1e-8)
+        self.assertGreater(result.temperature_c[300], result.temperature_c[-1])
+
+    def test_smaller_time_step_converges_for_constant_current(self):
+        coarse = simulate_lumped_temperature([75.0] * 600)
+        fine_spec = LumpedThermalSpec(time_step_s=0.5)
+        fine = simulate_lumped_temperature([75.0] * 1200, fine_spec)
+        self.assertLess(
+            abs(coarse.temperature_c[-1] - fine.temperature_c[-1]),
+            0.01,
+        )
+
+    def test_rejects_invalid_parameters(self):
+        with self.assertRaisesRegex(ValueError, "mass_kg must be positive"):
+            simulate_lumped_temperature([10.0], LumpedThermalSpec(mass_kg=0.0))
+        with self.assertRaisesRegex(ValueError, "resistance_ohm"):
+            simulate_lumped_temperature(
+                [10.0],
+                LumpedThermalSpec(resistance_ohm=-0.01),
+            )
+
+    def test_rejects_empty_or_nonfinite_current_profiles(self):
+        with self.assertRaisesRegex(ValueError, "at least one interval"):
+            simulate_lumped_temperature([])
+        with self.assertRaisesRegex(ValueError, "current values must be finite"):
+            simulate_lumped_temperature([math.nan])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a dependency-free one-node cell thermal reference model
- expose interval heat generation/rejection and a discrete energy-balance diagnostic
- add a constant-current CLI with explicit parameter validation
- add six tests for equilibrium, heating, timestep convergence, energy closure, and invalid inputs
- run model tests and Markdown links on pull requests and `main`
- document equations, assumptions, limitations, and the reproducible reference command

## Why

The repository promises reproducible thermal examples but previously contained only notes and templates. This model turns the simplest documented `I^2 R` heat source and linear heat-rejection assumptions into an executable, auditable baseline without introducing third-party dependencies.

## Validation

- `python -m unittest discover -s tests -v` (6 tests passed)
- reference CLI: 34.309 degC final temperature after 600 seconds at 75 A
- energy-balance error: `1.818989e-12 J`
- all repository Markdown links passed
- `npx --yes markdownlint-cli2 README.md CONTRIBUTING.md models/README.md`
- `npx --yes prettier --check .github/workflows/markdown-maintenance.yml`
- `git diff --check`