### PR TITLE
Add temperature-dependent resistance feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ LICENSE
 ## Run The Executable Reference
 
 The dependency-free lumped model implements irreversible `I^2 R` heating,
-linear heat rejection, and a discrete energy-balance diagnostic:
+optional linear resistance-temperature feedback, linear heat rejection, and a
+discrete energy-balance diagnostic:
 
 ```powershell
 python models/lumped_cell_thermal.py --current-a 75 --duration-s 600

--- a/models/README.md
+++ b/models/README.md
@@ -11,6 +11,7 @@ For each time interval, the model evaluates:
 
 ```text
 Q_generation = I^2 R
+R(T) = R_ref [1 + alpha (T_cell - T_ref)]
 Q_rejection = h (T_cell - T_ambient)
 C_thermal dT/dt = Q_generation - Q_rejection
 C_thermal = mass * specific_heat
@@ -33,7 +34,8 @@ python models/lumped_cell_thermal.py `
 
 The default case represents a 75 A constant-current interval applied to a
 1.05 kg lumped cell with 1000 J/(kg K) specific heat, 4 mOhm resistance,
-1.2 W/K heat transfer, and 25 degC initial and ambient temperature.
+zero resistance temperature coefficient, 1.2 W/K heat transfer, and 25 degC
+initial and ambient temperature.
 
 Run the regression checks with:
 
@@ -65,7 +67,8 @@ python models/lumped_cell_thermal.py `
 ```
 
 The output records interval boundaries, current, start/end temperature,
-ambient temperature, generated and rejected heat rates, and net interval heat.
+ambient temperature, evaluated resistance, generated and rejected heat rates,
+and net interval heat.
 Profile mode derives the time step from the CSV and rejects `--current-a`,
 `--duration-s`, or `--time-step-s` overrides.
 
@@ -82,9 +85,39 @@ A two-column profile uses `--ambient-temperature-c` or its 25 degC default. A
 three-column profile cannot be combined with that option because the interval
 values are authoritative.
 
+## Temperature-Dependent Resistance
+
+Set `--resistance-temperature-coefficient-per-k` to evaluate a linear
+temperature correction around `--resistance-reference-temperature-c`. A
+positive coefficient increases irreversible heat as the cell warms, making the
+electrical-to-thermal feedback visible while preserving a one-node model:
+
+```powershell
+python models/lumped_cell_thermal.py `
+  --current-a 100 --duration-s 600 `
+  --resistance-temperature-coefficient-per-k 0.01 `
+  --resistance-reference-temperature-c 25
+```
+
+Expected key values for that illustrative case:
+
+```text
+Final temperature: 43.351 degC
+Peak temperature: 43.351 degC
+Resistance range: 0.004000 to 0.004733 ohm
+```
+
+The coefficient defaults to zero, so all existing reference cases retain their
+constant-resistance behavior. Every interval records the evaluated resistance,
+and a configuration that produces negative resistance at an evaluated
+temperature is rejected. Replace the reference resistance, coefficient, and
+temperature with values fitted or measured for the target cell and operating
+window before engineering use.
+
 ## Explicit Limitations
 
-- Resistance is constant and does not vary with SOC, temperature, or age.
+- Resistance may use an optional linear temperature coefficient, but it does
+  not vary with SOC or age and does not represent a nonlinear measured map.
 - Heat generation contains irreversible ohmic loss only.
 - Reversible entropic heat is excluded.
 - The cell is represented by one uniform temperature state.

--- a/models/lumped_cell_thermal.py
+++ b/models/lumped_cell_thermal.py
@@ -15,6 +15,8 @@ class LumpedThermalSpec:
     mass_kg: float = 1.05
     specific_heat_j_per_kg_k: float = 1000.0
     resistance_ohm: float = 0.004
+    resistance_temperature_coefficient_per_k: float = 0.0
+    resistance_reference_temperature_c: float = 25.0
     heat_transfer_w_per_k: float = 1.2
     ambient_temperature_c: float = 25.0
     initial_temperature_c: float = 25.0
@@ -29,6 +31,12 @@ class LumpedThermalSpec:
             "mass_kg": self.mass_kg,
             "specific_heat_j_per_kg_k": self.specific_heat_j_per_kg_k,
             "resistance_ohm": self.resistance_ohm,
+            "resistance_temperature_coefficient_per_k": (
+                self.resistance_temperature_coefficient_per_k
+            ),
+            "resistance_reference_temperature_c": (
+                self.resistance_reference_temperature_c
+            ),
             "heat_transfer_w_per_k": self.heat_transfer_w_per_k,
             "ambient_temperature_c": self.ambient_temperature_c,
             "initial_temperature_c": self.initial_temperature_c,
@@ -48,6 +56,21 @@ class LumpedThermalSpec:
             raise ValueError("heat_transfer_w_per_k must be nonnegative")
         if self.time_step_s <= 0.0:
             raise ValueError("time_step_s must be positive")
+        self.resistance_at_temperature(self.initial_temperature_c)
+
+    def resistance_at_temperature(self, temperature_c: float) -> float:
+        """Evaluate the configured linear resistance-temperature relation."""
+
+        if not math.isfinite(temperature_c):
+            raise ValueError("temperature_c must be finite")
+        resistance_factor = 1.0 + (
+            self.resistance_temperature_coefficient_per_k
+            * (temperature_c - self.resistance_reference_temperature_c)
+        )
+        resistance_ohm = self.resistance_ohm * resistance_factor
+        if resistance_ohm < 0.0:
+            raise ValueError("temperature-dependent resistance must remain nonnegative")
+        return resistance_ohm
 
 
 @dataclass(frozen=True)
@@ -58,6 +81,7 @@ class ThermalSimulation:
     temperature_c: tuple[float, ...]
     current_a: tuple[float, ...]
     ambient_temperature_c: tuple[float, ...]
+    resistance_ohm: tuple[float, ...]
     heat_generation_w: tuple[float, ...]
     heat_rejection_w: tuple[float, ...]
     thermal_capacity_j_per_k: float
@@ -202,12 +226,14 @@ def simulate_lumped_temperature(
     temperatures = [spec.initial_temperature_c]
     generated_heat: list[float] = []
     rejected_heat: list[float] = []
+    interval_resistance: list[float] = []
 
     for current, ambient_temperature_c in zip(
         currents, ambient_temperatures, strict=True
     ):
         temperature = temperatures[-1]
-        generation_w = current * current * spec.resistance_ohm
+        resistance_ohm = spec.resistance_at_temperature(temperature)
+        generation_w = current * current * resistance_ohm
         rejection_w = spec.heat_transfer_w_per_k * (temperature - ambient_temperature_c)
         temperature_change_c = (
             (generation_w - rejection_w)
@@ -215,6 +241,7 @@ def simulate_lumped_temperature(
             / spec.thermal_capacity_j_per_k
         )
 
+        interval_resistance.append(resistance_ohm)
         generated_heat.append(generation_w)
         rejected_heat.append(rejection_w)
         temperatures.append(temperature + temperature_change_c)
@@ -225,6 +252,7 @@ def simulate_lumped_temperature(
         temperature_c=tuple(temperatures),
         current_a=currents,
         ambient_temperature_c=ambient_temperatures,
+        resistance_ohm=tuple(interval_resistance),
         heat_generation_w=tuple(generated_heat),
         heat_rejection_w=tuple(rejected_heat),
         thermal_capacity_j_per_k=spec.thermal_capacity_j_per_k,
@@ -241,6 +269,7 @@ def write_simulation_csv(path: Path, result: ThermalSimulation) -> None:
         "interval_end_s",
         "current_a",
         "ambient_temperature_c",
+        "resistance_ohm",
         "start_temperature_c",
         "end_temperature_c",
         "heat_generation_w",
@@ -258,6 +287,7 @@ def write_simulation_csv(path: Path, result: ThermalSimulation) -> None:
                 "interval_end_s": result.time_s[index + 1],
                 "current_a": current_a,
                 "ambient_temperature_c": result.ambient_temperature_c[index],
+                "resistance_ohm": result.resistance_ohm[index],
                 "start_temperature_c": result.temperature_c[index],
                 "end_temperature_c": result.temperature_c[index + 1],
                 "heat_generation_w": generated_w,
@@ -279,6 +309,16 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--duration-s", type=float)
     parser.add_argument("--time-step-s", type=float)
     parser.add_argument("--resistance-ohm", type=float, default=0.004)
+    parser.add_argument(
+        "--resistance-temperature-coefficient-per-k",
+        type=float,
+        default=0.0,
+    )
+    parser.add_argument(
+        "--resistance-reference-temperature-c",
+        type=float,
+        default=25.0,
+    )
     parser.add_argument("--heat-transfer-w-per-k", type=float, default=1.2)
     parser.add_argument("--ambient-temperature-c", type=float)
     parser.add_argument("--initial-temperature-c", type=float, default=25.0)
@@ -337,6 +377,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         mass_kg=args.mass_kg,
         specific_heat_j_per_kg_k=args.specific_heat_j_per_kg_k,
         resistance_ohm=args.resistance_ohm,
+        resistance_temperature_coefficient_per_k=(
+            args.resistance_temperature_coefficient_per_k
+        ),
+        resistance_reference_temperature_c=(args.resistance_reference_temperature_c),
         heat_transfer_w_per_k=args.heat_transfer_w_per_k,
         ambient_temperature_c=ambient_temperature_c,
         initial_temperature_c=args.initial_temperature_c,
@@ -351,6 +395,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     print(f"Duration: {len(currents) * time_step_s:.3f} s")
     print(f"Final temperature: {result.temperature_c[-1]:.3f} degC")
     print(f"Peak temperature: {result.peak_temperature_c:.3f} degC")
+    print(
+        "Resistance range: "
+        f"{min(result.resistance_ohm):.6f} to "
+        f"{max(result.resistance_ohm):.6f} ohm"
+    )
     print(f"Stored thermal energy: {result.stored_energy_change_j:.3f} J")
     print(f"Integrated net heat: {result.integrated_net_heat_j:.3f} J")
     print(f"Energy-balance error: {result.energy_balance_error_j:.6e} J")

--- a/tests/test_lumped_cell_thermal.py
+++ b/tests/test_lumped_cell_thermal.py
@@ -53,6 +53,68 @@ class LumpedCellThermalTests(unittest.TestCase):
         self.assertLess(result.energy_balance_error_j, 1e-8)
         self.assertGreater(result.temperature_c[300], result.temperature_c[-1])
 
+    def test_default_resistance_trace_remains_constant(self):
+        result = simulate_lumped_temperature([75.0] * 120)
+        self.assertEqual(result.resistance_ohm, (0.004,) * 120)
+        self.assertTrue(
+            all(
+                math.isclose(heat_w, 75.0**2 * 0.004)
+                for heat_w in result.heat_generation_w
+            )
+        )
+
+    def test_temperature_feedback_matches_closed_form_discrete_solution(self):
+        spec = LumpedThermalSpec(
+            mass_kg=1.0,
+            specific_heat_j_per_kg_k=1000.0,
+            resistance_ohm=0.01,
+            resistance_temperature_coefficient_per_k=0.02,
+            resistance_reference_temperature_c=25.0,
+            heat_transfer_w_per_k=0.0,
+            ambient_temperature_c=25.0,
+            initial_temperature_c=25.0,
+            time_step_s=1.0,
+        )
+        current_a = 100.0
+        intervals = 100
+        result = simulate_lumped_temperature([current_a] * intervals, spec)
+        base_step_c = (
+            current_a**2
+            * spec.resistance_ohm
+            * spec.time_step_s
+            / spec.thermal_capacity_j_per_k
+        )
+        recurrence_factor = (
+            1.0 + base_step_c * spec.resistance_temperature_coefficient_per_k
+        )
+        expected_rise_c = (
+            base_step_c
+            * (recurrence_factor**intervals - 1.0)
+            / (recurrence_factor - 1.0)
+        )
+        self.assertAlmostEqual(
+            result.temperature_c[-1],
+            spec.initial_temperature_c + expected_rise_c,
+            places=10,
+        )
+        self.assertEqual(result.resistance_ohm[0], spec.resistance_ohm)
+        self.assertGreater(result.resistance_ohm[-1], result.resistance_ohm[0])
+        self.assertLess(result.energy_balance_error_j, 1e-8)
+
+    def test_positive_temperature_coefficient_increases_peak_temperature(self):
+        constant = simulate_lumped_temperature([100.0] * 600)
+        feedback = simulate_lumped_temperature(
+            [100.0] * 600,
+            LumpedThermalSpec(
+                resistance_temperature_coefficient_per_k=0.01,
+            ),
+        )
+        self.assertGreater(feedback.peak_temperature_c, constant.peak_temperature_c)
+        self.assertGreater(
+            feedback.heat_generation_w[-1],
+            constant.heat_generation_w[-1],
+        )
+
     def test_smaller_time_step_converges_for_constant_current(self):
         coarse = simulate_lumped_temperature([75.0] * 600)
         fine_spec = LumpedThermalSpec(time_step_s=0.5)
@@ -69,6 +131,21 @@ class LumpedCellThermalTests(unittest.TestCase):
             simulate_lumped_temperature(
                 [10.0],
                 LumpedThermalSpec(resistance_ohm=-0.01),
+            )
+        with self.assertRaisesRegex(ValueError, "coefficient_per_k must be finite"):
+            simulate_lumped_temperature(
+                [10.0],
+                LumpedThermalSpec(
+                    resistance_temperature_coefficient_per_k=math.nan,
+                ),
+            )
+        with self.assertRaisesRegex(ValueError, "must remain nonnegative"):
+            simulate_lumped_temperature(
+                [10.0],
+                LumpedThermalSpec(
+                    initial_temperature_c=40.0,
+                    resistance_temperature_coefficient_per_k=-0.10,
+                ),
             )
 
     def test_rejects_empty_or_nonfinite_current_profiles(self):
@@ -142,6 +219,7 @@ class LumpedCellThermalTests(unittest.TestCase):
         self.assertEqual(len(rows), 2)
         self.assertEqual(float(rows[0]["current_a"]), 50.0)
         self.assertEqual(float(rows[0]["ambient_temperature_c"]), 25.0)
+        self.assertEqual(float(rows[0]["resistance_ohm"]), 0.004)
         self.assertAlmostEqual(
             sum(float(row["net_heat_j"]) for row in rows),
             result.integrated_net_heat_j,
@@ -169,6 +247,27 @@ class LumpedCellThermalTests(unittest.TestCase):
             self.assertTrue(output_path.is_file())
             self.assertIn("Intervals: 3", standard_output.getvalue())
             self.assertIn("Duration: 180.000 s", standard_output.getvalue())
+
+    def test_cli_reports_temperature_dependent_resistance_range(self):
+        standard_output = io.StringIO()
+        with contextlib.redirect_stdout(standard_output):
+            exit_code = main(
+                [
+                    "--current-a",
+                    "100",
+                    "--duration-s",
+                    "120",
+                    "--resistance-temperature-coefficient-per-k",
+                    "0.01",
+                ]
+            )
+        self.assertEqual(exit_code, 0)
+        output = standard_output.getvalue()
+        self.assertIn("Resistance range: 0.004000 to ", output)
+        upper_resistance = float(
+            output.split("Resistance range: 0.004000 to ", 1)[1].split(" ", 1)[0]
+        )
+        self.assertGreater(upper_resistance, 0.004)
 
     def test_cli_uses_profile_ambient_in_export(self):
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
## Summary

- add an optional linear resistance-temperature coefficient and reference temperature to the lumped cell specification
- evaluate and record resistance at each interval before calculating irreversible `I^2 R` heat
- export interval resistance in the auditable CSV schema and report its CLI range
- preserve every existing reference result with the zero-coefficient default
- document equations, calibration requirements, limitations, and a reproducible feedback case

## Why

The executable model and its documentation explicitly treated resistance as constant. That omitted a useful electrical-to-thermal feedback path and made it impossible to trace which resistance produced each interval's heat-generation value.

## Impact

Existing callers retain constant resistance because the new coefficient defaults to zero. Configured cases use `R(T) = R_ref [1 + alpha (T - T_ref)]`; negative evaluated resistance is rejected. The result and CSV expose the resistance trace so heat-generation calculations remain auditable.

## Validation

- `python -m unittest discover -s tests -v` (20 tests passed)
- independent 50-digit Decimal recurrence: `43.351020331201 degC`, `0.004733075537 ohm` peak resistance, and `19268.571347762 J` integrated net heat
- legacy 75 A case unchanged: `34.309 degC` and `1.818989e-12 J` energy-balance error
- committed ambient-step case unchanged: `29.964 degC` and `2.728484e-12 J` energy-balance error
- `uvx ruff check models tests` and changed-file format check (pass)
- Python 3.12 byte-compilation (pass)
- Markdown lint for changed documentation (0 errors)
- `git diff --check` (pass)