### PR TITLE
Add exact linear thermal integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,11 +93,15 @@ LICENSE
 ## Run The Executable Reference
 
 The dependency-free lumped model implements irreversible `I^2 R` heating,
-optional linear resistance-temperature feedback, linear heat rejection, and a
-discrete energy-balance diagnostic:
+optional linear resistance-temperature feedback, linear heat rejection,
+explicit Euler or exact linear interval integration, and an energy-balance
+diagnostic:
 
 ```powershell
 python models/lumped_cell_thermal.py --current-a 75 --duration-s 600
+python models/lumped_cell_thermal.py `
+  --current-a 75 --duration-s 600 --time-step-s 600 `
+  --integration-method exact-linear
 python models/lumped_cell_thermal.py `
   --profile-csv models/data/pulse_current_profile.csv `
   --output-csv results/pulse_thermal_intervals.csv

--- a/models/README.md
+++ b/models/README.md
@@ -17,9 +17,11 @@ C_thermal dT/dt = Q_generation - Q_rejection
 C_thermal = mass * specific_heat
 ```
 
-The temperature state is advanced with an explicit Euler step. The returned
-result includes stored thermal energy, integrated net heat, and their absolute
-difference so discretization and implementation changes can be audited.
+The default method advances temperature with an explicit Euler step. The
+optional exact linear method solves each piecewise-constant interval
+analytically. The returned result includes stored thermal energy, integrated
+net heat, and their absolute difference so discretization and implementation
+changes can be audited.
 
 ## Run The Reference Case
 
@@ -42,6 +44,30 @@ Run the regression checks with:
 ```powershell
 python -m unittest discover -s tests -v
 ```
+
+## Exact Linear Integration
+
+Use `--integration-method exact-linear` when a coarse interval would make an
+explicit Euler approximation unnecessarily sensitive to time-step size:
+
+```powershell
+python models/lumped_cell_thermal.py `
+  --current-a 75 --duration-s 600 --time-step-s 600 `
+  --integration-method exact-linear
+```
+
+With constant current and ambient over an interval, linear heat rejection and
+the configured linear resistance-temperature relation produce a linear ODE.
+The exact method evaluates its exponential solution with `expm1` for numerical
+stability. It also stores the exact net interval heat as thermal capacity times
+the temperature change. CSV `heat_generation_w`, `heat_rejection_w`, and
+`resistance_ohm` remain start-of-interval values; `net_heat_j` is the integrated
+interval quantity.
+
+The exact method removes integration error for this model equation, but it does
+not make piecewise-constant current, ambient, parameter, or one-node
+assumptions more accurate. Keep explicit Euler for educational recurrence
+comparisons or backward-compatible result reproduction.
 
 ## Run A Current And Ambient Profile
 
@@ -128,3 +154,6 @@ window before engineering use.
   engineering decisions.
 - Current-profile timestamps are treated as interval starts with piecewise
   constant current and ambient temperature over each interval.
+- Exact integration applies only to the model's linear within-interval
+  equation; nonlinear resistance maps or radiation would require a different
+  solver.

--- a/models/lumped_cell_thermal.py
+++ b/models/lumped_cell_thermal.py
@@ -4,8 +4,14 @@ import argparse
 import csv
 import math
 from dataclasses import dataclass
+from enum import Enum
 from pathlib import Path
 from typing import Sequence
+
+
+class IntegrationMethod(str, Enum):
+    EXPLICIT_EULER = "explicit-euler"
+    EXACT_LINEAR = "exact-linear"
 
 
 @dataclass(frozen=True)
@@ -21,12 +27,14 @@ class LumpedThermalSpec:
     ambient_temperature_c: float = 25.0
     initial_temperature_c: float = 25.0
     time_step_s: float = 1.0
+    integration_method: IntegrationMethod | str = IntegrationMethod.EXPLICIT_EULER
 
     @property
     def thermal_capacity_j_per_k(self) -> float:
         return self.mass_kg * self.specific_heat_j_per_kg_k
 
     def validate(self) -> None:
+        self.resolved_integration_method()
         finite_values = {
             "mass_kg": self.mass_kg,
             "specific_heat_j_per_kg_k": self.specific_heat_j_per_kg_k,
@@ -58,6 +66,15 @@ class LumpedThermalSpec:
             raise ValueError("time_step_s must be positive")
         self.resistance_at_temperature(self.initial_temperature_c)
 
+    def resolved_integration_method(self) -> IntegrationMethod:
+        """Return the configured integration method as a validated enum."""
+
+        try:
+            return IntegrationMethod(self.integration_method)
+        except ValueError as error:
+            choices = ", ".join(method.value for method in IntegrationMethod)
+            raise ValueError(f"integration_method must be one of: {choices}") from error
+
     def resistance_at_temperature(self, temperature_c: float) -> float:
         """Evaluate the configured linear resistance-temperature relation."""
 
@@ -84,8 +101,10 @@ class ThermalSimulation:
     resistance_ohm: tuple[float, ...]
     heat_generation_w: tuple[float, ...]
     heat_rejection_w: tuple[float, ...]
+    interval_net_heat_j: tuple[float, ...]
     thermal_capacity_j_per_k: float
     time_step_s: float
+    integration_method: IntegrationMethod
 
     @property
     def peak_temperature_c(self) -> float:
@@ -99,14 +118,7 @@ class ThermalSimulation:
 
     @property
     def integrated_net_heat_j(self) -> float:
-        return sum(
-            (generated - rejected) * self.time_step_s
-            for generated, rejected in zip(
-                self.heat_generation_w,
-                self.heat_rejection_w,
-                strict=True,
-            )
-        )
+        return sum(self.interval_net_heat_j)
 
     @property
     def energy_balance_error_j(self) -> float:
@@ -201,9 +213,10 @@ def simulate_lumped_temperature(
     spec: LumpedThermalSpec = LumpedThermalSpec(),
     ambient_temperatures_c: Sequence[float] | None = None,
 ) -> ThermalSimulation:
-    """Integrate a one-node thermal balance with explicit Euler steps."""
+    """Integrate a one-node thermal balance over piecewise-constant intervals."""
 
     spec.validate()
+    integration_method = spec.resolved_integration_method()
     currents = tuple(float(current) for current in currents_a)
     if not currents:
         raise ValueError("currents_a must contain at least one interval")
@@ -226,6 +239,7 @@ def simulate_lumped_temperature(
     temperatures = [spec.initial_temperature_c]
     generated_heat: list[float] = []
     rejected_heat: list[float] = []
+    interval_net_heat: list[float] = []
     interval_resistance: list[float] = []
 
     for current, ambient_temperature_c in zip(
@@ -235,16 +249,48 @@ def simulate_lumped_temperature(
         resistance_ohm = spec.resistance_at_temperature(temperature)
         generation_w = current * current * resistance_ohm
         rejection_w = spec.heat_transfer_w_per_k * (temperature - ambient_temperature_c)
-        temperature_change_c = (
-            (generation_w - rejection_w)
-            * spec.time_step_s
-            / spec.thermal_capacity_j_per_k
-        )
+        net_heat_w = generation_w - rejection_w
+        if integration_method is IntegrationMethod.EXPLICIT_EULER:
+            temperature_change_c = (
+                net_heat_w * spec.time_step_s / spec.thermal_capacity_j_per_k
+            )
+        else:
+            thermal_feedback_w_per_k = (
+                current
+                * current
+                * spec.resistance_ohm
+                * spec.resistance_temperature_coefficient_per_k
+                - spec.heat_transfer_w_per_k
+            )
+            if thermal_feedback_w_per_k == 0.0:
+                temperature_change_c = (
+                    net_heat_w * spec.time_step_s / spec.thermal_capacity_j_per_k
+                )
+            else:
+                exponent = (
+                    thermal_feedback_w_per_k
+                    * spec.time_step_s
+                    / spec.thermal_capacity_j_per_k
+                )
+                try:
+                    temperature_change_c = (
+                        net_heat_w * math.expm1(exponent) / thermal_feedback_w_per_k
+                    )
+                except OverflowError as error:
+                    raise ValueError(
+                        "exact integration produced a non-finite temperature"
+                    ) from error
+
+        next_temperature_c = temperature + temperature_change_c
+        if not math.isfinite(next_temperature_c):
+            raise ValueError("integration produced a non-finite temperature")
+        spec.resistance_at_temperature(next_temperature_c)
 
         interval_resistance.append(resistance_ohm)
         generated_heat.append(generation_w)
         rejected_heat.append(rejection_w)
-        temperatures.append(temperature + temperature_change_c)
+        interval_net_heat.append(temperature_change_c * spec.thermal_capacity_j_per_k)
+        temperatures.append(next_temperature_c)
 
     times = tuple(index * spec.time_step_s for index in range(len(currents) + 1))
     return ThermalSimulation(
@@ -255,8 +301,10 @@ def simulate_lumped_temperature(
         resistance_ohm=tuple(interval_resistance),
         heat_generation_w=tuple(generated_heat),
         heat_rejection_w=tuple(rejected_heat),
+        interval_net_heat_j=tuple(interval_net_heat),
         thermal_capacity_j_per_k=spec.thermal_capacity_j_per_k,
         time_step_s=spec.time_step_s,
+        integration_method=integration_method,
     )
 
 
@@ -292,7 +340,7 @@ def write_simulation_csv(path: Path, result: ThermalSimulation) -> None:
                 "end_temperature_c": result.temperature_c[index + 1],
                 "heat_generation_w": generated_w,
                 "heat_rejection_w": rejected_w,
-                "net_heat_j": (generated_w - rejected_w) * result.time_step_s,
+                "net_heat_j": result.interval_net_heat_j[index],
             }
             writer.writerow(
                 {name: format(value, ".12g") for name, value in values.items()}
@@ -324,6 +372,11 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--initial-temperature-c", type=float, default=25.0)
     parser.add_argument("--mass-kg", type=float, default=1.05)
     parser.add_argument("--specific-heat-j-per-kg-k", type=float, default=1000.0)
+    parser.add_argument(
+        "--integration-method",
+        choices=tuple(method.value for method in IntegrationMethod),
+        default=IntegrationMethod.EXPLICIT_EULER.value,
+    )
     return parser.parse_args(argv)
 
 
@@ -385,6 +438,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         ambient_temperature_c=ambient_temperature_c,
         initial_temperature_c=args.initial_temperature_c,
         time_step_s=time_step_s,
+        integration_method=args.integration_method,
     )
     result = simulate_lumped_temperature(currents, spec, ambient_temperatures_c)
 
@@ -393,6 +447,7 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     print(f"Intervals: {len(currents)}")
     print(f"Duration: {len(currents) * time_step_s:.3f} s")
+    print(f"Integration method: {result.integration_method.value}")
     print(f"Final temperature: {result.temperature_c[-1]:.3f} degC")
     print(f"Peak temperature: {result.peak_temperature_c:.3f} degC")
     print(

--- a/tests/test_lumped_cell_thermal.py
+++ b/tests/test_lumped_cell_thermal.py
@@ -9,6 +9,7 @@ import unittest
 from pathlib import Path
 
 from models.lumped_cell_thermal import (
+    IntegrationMethod,
     LumpedThermalSpec,
     load_current_profile,
     main,
@@ -46,6 +47,71 @@ class LumpedCellThermalTests(unittest.TestCase):
             result.temperature_c[-1],
             spec.ambient_temperature_c + steady_rise_c,
         )
+
+    def test_exact_linear_matches_constant_current_analytic_solution(self):
+        spec = LumpedThermalSpec(
+            time_step_s=600.0,
+            integration_method=IntegrationMethod.EXACT_LINEAR,
+        )
+        current_a = 75.0
+        result = simulate_lumped_temperature([current_a], spec)
+
+        steady_rise_c = (
+            current_a * current_a * spec.resistance_ohm / spec.heat_transfer_w_per_k
+        )
+        expected_c = spec.ambient_temperature_c + steady_rise_c * (
+            1.0
+            - math.exp(
+                -spec.heat_transfer_w_per_k
+                * spec.time_step_s
+                / spec.thermal_capacity_j_per_k
+            )
+        )
+        self.assertAlmostEqual(result.temperature_c[-1], expected_c, places=12)
+        self.assertIs(result.integration_method, IntegrationMethod.EXACT_LINEAR)
+        self.assertLess(result.energy_balance_error_j, 1e-9)
+
+    def test_exact_linear_matches_temperature_feedback_solution(self):
+        spec = LumpedThermalSpec(
+            mass_kg=1.0,
+            specific_heat_j_per_kg_k=1000.0,
+            resistance_ohm=0.01,
+            resistance_temperature_coefficient_per_k=0.02,
+            resistance_reference_temperature_c=25.0,
+            heat_transfer_w_per_k=0.0,
+            initial_temperature_c=25.0,
+            time_step_s=100.0,
+            integration_method="exact-linear",
+        )
+        result = simulate_lumped_temperature([100.0], spec)
+        expected_rise_c = math.expm1(0.2) / 0.02
+
+        self.assertAlmostEqual(
+            result.temperature_c[-1],
+            spec.initial_temperature_c + expected_rise_c,
+            places=12,
+        )
+        self.assertGreater(
+            result.interval_net_heat_j[0],
+            result.heat_generation_w[0] * spec.time_step_s,
+        )
+
+    def test_exact_linear_handles_zero_net_feedback_slope(self):
+        spec = LumpedThermalSpec(
+            mass_kg=1.0,
+            specific_heat_j_per_kg_k=1000.0,
+            resistance_ohm=0.01,
+            resistance_temperature_coefficient_per_k=0.01,
+            resistance_reference_temperature_c=25.0,
+            heat_transfer_w_per_k=1.0,
+            ambient_temperature_c=25.0,
+            initial_temperature_c=25.0,
+            time_step_s=100.0,
+            integration_method=IntegrationMethod.EXACT_LINEAR,
+        )
+        result = simulate_lumped_temperature([100.0], spec)
+        self.assertAlmostEqual(result.temperature_c[-1], 35.0, places=12)
+        self.assertAlmostEqual(result.interval_net_heat_j[0], 10_000.0, places=9)
 
     def test_discrete_energy_balance_closes(self):
         profile = [80.0] * 300 + [0.0] * 300
@@ -147,6 +213,11 @@ class LumpedCellThermalTests(unittest.TestCase):
                     resistance_temperature_coefficient_per_k=-0.10,
                 ),
             )
+        with self.assertRaisesRegex(ValueError, "integration_method must be one of"):
+            simulate_lumped_temperature(
+                [10.0],
+                LumpedThermalSpec(integration_method="runge-kutta"),
+            )
 
     def test_rejects_empty_or_nonfinite_current_profiles(self):
         with self.assertRaisesRegex(ValueError, "at least one interval"):
@@ -225,6 +296,31 @@ class LumpedCellThermalTests(unittest.TestCase):
             result.integrated_net_heat_j,
         )
 
+    def test_exact_linear_export_uses_integrated_interval_heat(self):
+        result = simulate_lumped_temperature(
+            [100.0],
+            LumpedThermalSpec(
+                time_step_s=120.0,
+                resistance_temperature_coefficient_per_k=0.02,
+                integration_method=IntegrationMethod.EXACT_LINEAR,
+            ),
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "result.csv"
+            write_simulation_csv(path, result)
+            with path.open("r", encoding="utf-8", newline="") as output_file:
+                row = next(csv.DictReader(output_file))
+        self.assertAlmostEqual(
+            float(row["net_heat_j"]),
+            result.interval_net_heat_j[0],
+            places=7,
+        )
+        self.assertAlmostEqual(
+            result.integrated_net_heat_j,
+            result.stored_energy_change_j,
+            places=9,
+        )
+
     def test_cli_runs_profile_and_exports_results(self):
         with tempfile.TemporaryDirectory() as directory:
             profile_path = Path(directory) / "profile.csv"
@@ -268,6 +364,29 @@ class LumpedCellThermalTests(unittest.TestCase):
             output.split("Resistance range: 0.004000 to ", 1)[1].split(" ", 1)[0]
         )
         self.assertGreater(upper_resistance, 0.004)
+
+    def test_cli_reports_exact_linear_integration(self):
+        standard_output = io.StringIO()
+        with contextlib.redirect_stdout(standard_output):
+            exit_code = main(
+                [
+                    "--current-a",
+                    "75",
+                    "--duration-s",
+                    "600",
+                    "--time-step-s",
+                    "600",
+                    "--integration-method",
+                    "exact-linear",
+                ]
+            )
+        self.assertEqual(exit_code, 0)
+        output = standard_output.getvalue()
+        self.assertIn("Integration method: exact-linear", output)
+        energy_error_j = float(
+            output.split("Energy-balance error: ", 1)[1].split(" ", 1)[0]
+        )
+        self.assertLess(energy_error_j, 1e-9)
 
     def test_cli_uses_profile_ambient_in_export(self):
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
## Summary
- add an opt-in exact per-interval solver for the linear one-node thermal balance
- preserve explicit Euler as the default integration method
- record integrated net interval heat consistently in simulation and CSV output
- document numerical scope, limitations, and CLI usage

## Validation
- `python -m unittest discover -s tests -q` (25 tests)
- `ruff check` on changed Python files
- `ruff format --check` on changed Python files
- `python -m compileall -q models tests`
- 10,000-case randomized comparison with an independent closed-form oracle
- coarse 600-second exact-integration CLI scenario