### PR TITLE
Add reversible entropic heat model

### DIFF
--- a/.github/workflows/markdown-maintenance.yml
+++ b/.github/workflows/markdown-maintenance.yml
@@ -35,6 +35,13 @@ jobs:
       - name: Test executable models
         run: python -m unittest discover -s tests -v
 
+      - name: Run reversible heat example
+        run: >-
+          python models/lumped_cell_thermal.py
+          --profile-csv models/data/reversible_heat_current_profile.csv
+          --integration-method exact-linear
+          --output-csv "$RUNNER_TEMP/reversible-heat-intervals.csv"
+
       - name: Check Markdown links
         uses: lycheeverse/lychee-action@v2
         with:

--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ LICENSE
 ## Run The Executable Reference
 
 The dependency-free lumped model implements irreversible `I^2 R` heating,
-optional linear resistance-temperature feedback, linear heat rejection,
-explicit Euler or exact linear interval integration, and an energy-balance
-diagnostic:
+optional reversible entropic heat, linear resistance-temperature feedback,
+linear heat rejection, explicit Euler or exact linear interval integration,
+and an energy-balance diagnostic:
 
 ```powershell
 python models/lumped_cell_thermal.py --current-a 75 --duration-s 600
@@ -112,14 +112,18 @@ python models/lumped_cell_thermal.py `
   --profile-csv models/data/irregular_current_profile.csv `
   --integration-method exact-linear `
   --output-csv results/irregular_thermal_intervals.csv
+python models/lumped_cell_thermal.py `
+  --profile-csv models/data/reversible_heat_current_profile.csv `
+  --integration-method exact-linear `
+  --output-csv results/reversible_heat_intervals.csv
 python -m unittest discover -s tests -v
 ```
 
 See the [model assumptions and limitations](models/README.md) before adapting
 the parameters or using the output in an engineering review. The profile path
 supports traceable charge/discharge duty cycles, optional interval ambient
-temperature, explicit nonuniform interval durations, and interval-level CSV
-results.
+temperature and entropic coefficients, explicit nonuniform interval durations,
+and interval-level CSV results.
 
 ## Contribution Entry Points
 

--- a/models/README.md
+++ b/models/README.md
@@ -10,7 +10,9 @@ or safety qualification.
 For each time interval, the model evaluates:
 
 ```text
-Q_generation = I^2 R
+Q_irreversible = I^2 R
+Q_reversible = -I T_kelvin dU_oc/dT
+Q_generation = Q_irreversible + Q_reversible
 R(T) = R_ref [1 + alpha (T_cell - T_ref)]
 Q_rejection = h (T_cell - T_ambient)
 C_thermal dT/dt = Q_generation - Q_rejection
@@ -36,8 +38,8 @@ python models/lumped_cell_thermal.py `
 
 The default case represents a 75 A constant-current interval applied to a
 1.05 kg lumped cell with 1000 J/(kg K) specific heat, 4 mOhm resistance,
-zero resistance temperature coefficient, 1.2 W/K heat transfer, and 25 degC
-initial and ambient temperature.
+zero resistance temperature coefficient, zero entropic coefficient, 1.2 W/K
+heat transfer, and 25 degC initial and ambient temperature.
 
 Run the regression checks with:
 
@@ -56,13 +58,14 @@ python models/lumped_cell_thermal.py `
   --integration-method exact-linear
 ```
 
-With constant current and ambient over an interval, linear heat rejection and
-the configured linear resistance-temperature relation produce a linear ODE.
+With constant current, ambient, and entropic coefficient over an interval,
+linear heat rejection, reversible heat, and the configured linear
+resistance-temperature relation produce a linear ODE.
 The exact method evaluates its exponential solution with `expm1` for numerical
 stability. It also stores the exact net interval heat as thermal capacity times
-the temperature change. CSV `heat_generation_w`, `heat_rejection_w`, and
-`resistance_ohm` remain start-of-interval values; `net_heat_j` is the integrated
-interval quantity.
+the temperature change. CSV heat rates, `resistance_ohm`, and
+`entropic_coefficient_v_per_k` remain start-of-interval values; `net_heat_j` is
+the integrated interval quantity.
 
 The exact method removes integration error for this model equation, but it does
 not make piecewise-constant current, ambient, parameter, or one-node
@@ -93,8 +96,9 @@ python models/lumped_cell_thermal.py `
 ```
 
 The output records interval boundaries and duration, current, start/end
-temperature, ambient temperature, evaluated resistance, generated and rejected
-heat rates, and net interval heat.
+temperature, ambient temperature, evaluated resistance, entropic coefficient,
+irreversible, reversible, total generated and rejected heat rates, and net
+interval heat.
 Profile mode derives the time step from the CSV and rejects `--current-a`,
 `--duration-s`, or `--time-step-s` overrides.
 
@@ -137,6 +141,39 @@ simulation exposes every interval duration, cumulative time boundaries, and
 the total elapsed duration. Its `time_step_s` compatibility property returns
 the common duration for a uniform grid and `None` for a variable grid.
 
+## Reversible Entropic Heat
+
+Use `--entropic-coefficient-v-per-k` to add the reversible Bernardi heat term.
+This model defines positive current as discharge and evaluates
+`Q_reversible = -I * T_kelvin * dU_oc/dT`; therefore reversing current reverses
+the reversible term while `I^2 R` remains nonnegative. A positive coefficient
+produces reversible cooling during positive-current discharge and heating
+during negative-current charge under this convention.
+
+The equation and interpretation follow the electrode-sandwich heat balance in
+the [NREL Li-Ion Battery Thermal Characterization report](https://www.nrel.gov/docs/fy24osti/89032.pdf),
+which separates irreversible overpotential heat from reversible entropic heat.
+Coefficient sign and magnitude vary with chemistry, SOC, and test method, so
+replace the illustrative values with cell-specific measurements.
+
+Run the committed charge/discharge example with an interval-varying coefficient:
+
+```powershell
+python models/lumped_cell_thermal.py `
+  --profile-csv models/data/reversible_heat_current_profile.csv `
+  --integration-method exact-linear `
+  --output-csv results/reversible-heat-intervals.csv
+```
+
+The Python API accepts `entropic_coefficients_v_per_k` with one value per
+current interval. A profile may add `entropic_coefficient_v_per_k` after the
+optional duration and ambient columns, allowing an externally prepared
+SOC-dependent coefficient schedule without claiming an electrical SOC model.
+Every result preserves the coefficient and separate irreversible, reversible,
+and total heat-source traces. For exact-linear integration, all reported heat
+rates are start-of-interval values while `net_heat_j` remains the exact
+integrated thermal-energy change.
+
 ## Temperature-Dependent Resistance
 
 Set `--resistance-temperature-coefficient-per-k` to evaluate a linear
@@ -170,8 +207,9 @@ window before engineering use.
 
 - Resistance may use an optional linear temperature coefficient, but it does
   not vary with SOC or age and does not represent a nonlinear measured map.
-- Heat generation contains irreversible ohmic loss only.
-- Reversible entropic heat is excluded.
+- Reversible heat uses a supplied constant or piecewise-constant entropic
+  coefficient; the model does not derive its SOC or chemistry dependence.
+- Mixing, phase-change, side-reaction, and interconnect heat are excluded.
 - The cell is represented by one uniform temperature state.
 - Heat transfer is linear; ambient may vary by interval, but the heat-transfer
   coefficient remains fixed.

--- a/models/README.md
+++ b/models/README.md
@@ -151,7 +151,7 @@ produces reversible cooling during positive-current discharge and heating
 during negative-current charge under this convention.
 
 The equation and interpretation follow the electrode-sandwich heat balance in
-the [NREL Li-Ion Battery Thermal Characterization report](https://www.nrel.gov/docs/fy24osti/89032.pdf),
+the [NREL Li-Ion Battery Thermal Characterization paper](https://www.osti.gov/biblio/2349292),
 which separates irreversible overpotential heat from reversible entropic heat.
 Coefficient sign and magnitude vary with chemistry, SOC, and test method, so
 replace the illustrative values with cell-specific measurements.

--- a/models/data/reversible_heat_current_profile.csv
+++ b/models/data/reversible_heat_current_profile.csv
@@ -1,0 +1,5 @@
+time_s,current_a,duration_s,ambient_temperature_c,entropic_coefficient_v_per_k
+0,0,60,25,0.0001
+60,80,120,25,0.0001
+180,-80,120,25,0.0001
+300,0,60,25,0.0001

--- a/models/lumped_cell_thermal.py
+++ b/models/lumped_cell_thermal.py
@@ -9,6 +9,9 @@ from pathlib import Path
 from typing import Sequence
 
 
+ABSOLUTE_ZERO_C = -273.15
+
+
 class IntegrationMethod(str, Enum):
     EXPLICIT_EULER = "explicit-euler"
     EXACT_LINEAR = "exact-linear"
@@ -23,6 +26,7 @@ class LumpedThermalSpec:
     resistance_ohm: float = 0.004
     resistance_temperature_coefficient_per_k: float = 0.0
     resistance_reference_temperature_c: float = 25.0
+    entropic_coefficient_v_per_k: float = 0.0
     heat_transfer_w_per_k: float = 1.2
     ambient_temperature_c: float = 25.0
     initial_temperature_c: float = 25.0
@@ -45,6 +49,7 @@ class LumpedThermalSpec:
             "resistance_reference_temperature_c": (
                 self.resistance_reference_temperature_c
             ),
+            "entropic_coefficient_v_per_k": self.entropic_coefficient_v_per_k,
             "heat_transfer_w_per_k": self.heat_transfer_w_per_k,
             "ambient_temperature_c": self.ambient_temperature_c,
             "initial_temperature_c": self.initial_temperature_c,
@@ -64,6 +69,12 @@ class LumpedThermalSpec:
             raise ValueError("heat_transfer_w_per_k must be nonnegative")
         if self.time_step_s <= 0.0:
             raise ValueError("time_step_s must be positive")
+        _temperature_k(self.ambient_temperature_c, "ambient_temperature_c")
+        _temperature_k(self.initial_temperature_c, "initial_temperature_c")
+        _temperature_k(
+            self.resistance_reference_temperature_c,
+            "resistance_reference_temperature_c",
+        )
         self.resistance_at_temperature(self.initial_temperature_c)
 
     def resolved_integration_method(self) -> IntegrationMethod:
@@ -78,8 +89,7 @@ class LumpedThermalSpec:
     def resistance_at_temperature(self, temperature_c: float) -> float:
         """Evaluate the configured linear resistance-temperature relation."""
 
-        if not math.isfinite(temperature_c):
-            raise ValueError("temperature_c must be finite")
+        _temperature_k(temperature_c, "temperature_c")
         resistance_factor = 1.0 + (
             self.resistance_temperature_coefficient_per_k
             * (temperature_c - self.resistance_reference_temperature_c)
@@ -88,6 +98,26 @@ class LumpedThermalSpec:
         if resistance_ohm < 0.0:
             raise ValueError("temperature-dependent resistance must remain nonnegative")
         return resistance_ohm
+
+    def reversible_heat_w(
+        self,
+        current_a: float,
+        temperature_c: float,
+        entropic_coefficient_v_per_k: float | None = None,
+    ) -> float:
+        """Return reversible heat for the positive-discharge convention."""
+
+        coefficient = (
+            self.entropic_coefficient_v_per_k
+            if entropic_coefficient_v_per_k is None
+            else entropic_coefficient_v_per_k
+        )
+        if not math.isfinite(current_a):
+            raise ValueError("current_a must be finite")
+        if not math.isfinite(coefficient):
+            raise ValueError("entropic_coefficient_v_per_k must be finite")
+        temperature_k = _temperature_k(temperature_c, "temperature_c")
+        return -current_a * temperature_k * coefficient
 
 
 @dataclass(frozen=True)
@@ -99,6 +129,9 @@ class ThermalSimulation:
     current_a: tuple[float, ...]
     ambient_temperature_c: tuple[float, ...]
     resistance_ohm: tuple[float, ...]
+    entropic_coefficient_v_per_k: tuple[float, ...]
+    irreversible_heat_w: tuple[float, ...]
+    reversible_heat_w: tuple[float, ...]
     heat_generation_w: tuple[float, ...]
     heat_rejection_w: tuple[float, ...]
     interval_net_heat_j: tuple[float, ...]
@@ -148,11 +181,12 @@ class ThermalSimulation:
 
 @dataclass(frozen=True)
 class CurrentProfile:
-    """Interval-start timestamps, durations, current, and optional ambient."""
+    """Interval starts, durations, current, ambient, and entropic coefficients."""
 
     time_s: tuple[float, ...]
     current_a: tuple[float, ...]
     ambient_temperature_c: tuple[float, ...] | None
+    entropic_coefficient_v_per_k: tuple[float, ...] | None
     interval_duration_s: tuple[float, ...]
 
     @property
@@ -173,31 +207,41 @@ class CurrentProfile:
         return None
 
 
+def _temperature_k(temperature_c: float, context: str) -> float:
+    if not math.isfinite(temperature_c):
+        raise ValueError(f"{context} must be finite")
+    if temperature_c <= ABSOLUTE_ZERO_C:
+        raise ValueError(f"{context} must be above absolute zero")
+    return temperature_c - ABSOLUTE_ZERO_C
+
+
 def load_current_profile(path: Path) -> CurrentProfile:
-    """Load a strict current profile with optional duration and ambient columns."""
+    """Load current, duration, ambient, and entropic-coefficient intervals."""
 
     with path.open("r", encoding="utf-8", newline="") as profile_file:
         reader = csv.DictReader(profile_file)
-        supported_headers = (
-            ["time_s", "current_a"],
-            ["time_s", "current_a", "ambient_temperature_c"],
-            ["time_s", "current_a", "duration_s"],
-            [
-                "time_s",
-                "current_a",
-                "duration_s",
-                "ambient_temperature_c",
-            ],
-        )
-        if reader.fieldnames not in supported_headers:
+        required_headers = ["time_s", "current_a"]
+        optional_headers = [
+            "duration_s",
+            "ambient_temperature_c",
+            "entropic_coefficient_v_per_k",
+        ]
+        fieldnames = reader.fieldnames or []
+        selected_optional_headers = [
+            header for header in optional_headers if header in fieldnames[2:]
+        ]
+        if (
+            fieldnames[:2] != required_headers
+            or fieldnames[2:] != selected_optional_headers
+        ):
             raise ValueError(
-                "profile CSV header must be exactly one of: time_s,current_a; "
-                "time_s,current_a,ambient_temperature_c; "
-                "time_s,current_a,duration_s; or "
-                "time_s,current_a,duration_s,ambient_temperature_c"
+                "profile CSV header must be exactly time_s,current_a followed by "
+                "any of duration_s,ambient_temperature_c,"
+                "entropic_coefficient_v_per_k in that order"
             )
-        has_ambient = "ambient_temperature_c" in reader.fieldnames
-        has_duration = "duration_s" in reader.fieldnames
+        has_ambient = "ambient_temperature_c" in fieldnames
+        has_duration = "duration_s" in fieldnames
+        has_entropic_coefficient = "entropic_coefficient_v_per_k" in fieldnames
         rows = list(reader)
 
     if not rows:
@@ -209,6 +253,7 @@ def load_current_profile(path: Path) -> CurrentProfile:
     currents: list[float] = []
     durations: list[float] = []
     ambient_temperatures: list[float] = []
+    entropic_coefficients: list[float] = []
     for line_number, row in enumerate(rows, start=2):
         try:
             time_s = float(row["time_s"])
@@ -216,6 +261,11 @@ def load_current_profile(path: Path) -> CurrentProfile:
             duration_s = float(row["duration_s"]) if has_duration else None
             ambient_temperature_c = (
                 float(row["ambient_temperature_c"]) if has_ambient else None
+            )
+            entropic_coefficient_v_per_k = (
+                float(row["entropic_coefficient_v_per_k"])
+                if has_entropic_coefficient
+                else None
             )
         except (TypeError, ValueError) as error:
             raise ValueError(
@@ -226,6 +276,8 @@ def load_current_profile(path: Path) -> CurrentProfile:
             values.append(duration_s)
         if ambient_temperature_c is not None:
             values.append(ambient_temperature_c)
+        if entropic_coefficient_v_per_k is not None:
+            values.append(entropic_coefficient_v_per_k)
         if None in row or any(not math.isfinite(value) for value in values):
             raise ValueError(f"profile CSV line {line_number} must be finite")
         if duration_s is not None and duration_s <= 0.0:
@@ -237,7 +289,13 @@ def load_current_profile(path: Path) -> CurrentProfile:
         if duration_s is not None:
             durations.append(duration_s)
         if ambient_temperature_c is not None:
+            _temperature_k(
+                ambient_temperature_c,
+                f"profile CSV line {line_number} ambient_temperature_c",
+            )
             ambient_temperatures.append(ambient_temperature_c)
+        if entropic_coefficient_v_per_k is not None:
+            entropic_coefficients.append(entropic_coefficient_v_per_k)
 
     if not math.isclose(times[0], 0.0, rel_tol=0.0, abs_tol=1e-12):
         raise ValueError("profile CSV time_s must start at zero")
@@ -281,6 +339,9 @@ def load_current_profile(path: Path) -> CurrentProfile:
         time_s=tuple(times),
         current_a=tuple(currents),
         ambient_temperature_c=(tuple(ambient_temperatures) if has_ambient else None),
+        entropic_coefficient_v_per_k=(
+            tuple(entropic_coefficients) if has_entropic_coefficient else None
+        ),
         interval_duration_s=tuple(durations),
     )
 
@@ -290,6 +351,7 @@ def simulate_lumped_temperature(
     spec: LumpedThermalSpec = LumpedThermalSpec(),
     ambient_temperatures_c: Sequence[float] | None = None,
     interval_durations_s: Sequence[float] | None = None,
+    entropic_coefficients_v_per_k: Sequence[float] | None = None,
 ) -> ThermalSimulation:
     """Integrate a one-node thermal balance over piecewise-constant intervals."""
 
@@ -326,22 +388,53 @@ def simulate_lumped_temperature(
             )
         if any(not math.isfinite(value) for value in ambient_temperatures):
             raise ValueError("all ambient temperature values must be finite")
+        for value in ambient_temperatures:
+            _temperature_k(value, "ambient temperature values")
+
+    if entropic_coefficients_v_per_k is None:
+        entropic_coefficients = (spec.entropic_coefficient_v_per_k,) * len(currents)
+    else:
+        entropic_coefficients = tuple(
+            float(value) for value in entropic_coefficients_v_per_k
+        )
+        if len(entropic_coefficients) != len(currents):
+            raise ValueError(
+                "entropic_coefficients_v_per_k must contain one value per "
+                "current interval"
+            )
+        if any(not math.isfinite(value) for value in entropic_coefficients):
+            raise ValueError("all entropic coefficient values must be finite")
 
     temperatures = [spec.initial_temperature_c]
+    irreversible_heat: list[float] = []
+    reversible_heat: list[float] = []
     generated_heat: list[float] = []
     rejected_heat: list[float] = []
     interval_net_heat: list[float] = []
     interval_resistance: list[float] = []
+    interval_entropic_coefficient: list[float] = []
 
-    for current, ambient_temperature_c, interval_duration_s in zip(
+    for (
+        current,
+        ambient_temperature_c,
+        interval_duration_s,
+        entropic_coefficient_v_per_k,
+    ) in zip(
         currents,
         ambient_temperatures,
         interval_durations,
+        entropic_coefficients,
         strict=True,
     ):
         temperature = temperatures[-1]
         resistance_ohm = spec.resistance_at_temperature(temperature)
-        generation_w = current * current * resistance_ohm
+        irreversible_w = current * current * resistance_ohm
+        reversible_w = spec.reversible_heat_w(
+            current,
+            temperature,
+            entropic_coefficient_v_per_k,
+        )
+        generation_w = irreversible_w + reversible_w
         rejection_w = spec.heat_transfer_w_per_k * (temperature - ambient_temperature_c)
         net_heat_w = generation_w - rejection_w
         if integration_method is IntegrationMethod.EXPLICIT_EULER:
@@ -354,6 +447,7 @@ def simulate_lumped_temperature(
                 * current
                 * spec.resistance_ohm
                 * spec.resistance_temperature_coefficient_per_k
+                - current * entropic_coefficient_v_per_k
                 - spec.heat_transfer_w_per_k
             )
             if thermal_feedback_w_per_k == 0.0:
@@ -378,9 +472,13 @@ def simulate_lumped_temperature(
         next_temperature_c = temperature + temperature_change_c
         if not math.isfinite(next_temperature_c):
             raise ValueError("integration produced a non-finite temperature")
+        _temperature_k(next_temperature_c, "integrated temperature")
         spec.resistance_at_temperature(next_temperature_c)
 
         interval_resistance.append(resistance_ohm)
+        interval_entropic_coefficient.append(entropic_coefficient_v_per_k)
+        irreversible_heat.append(irreversible_w)
+        reversible_heat.append(reversible_w)
         generated_heat.append(generation_w)
         rejected_heat.append(rejection_w)
         interval_net_heat.append(temperature_change_c * spec.thermal_capacity_j_per_k)
@@ -395,6 +493,9 @@ def simulate_lumped_temperature(
         current_a=currents,
         ambient_temperature_c=ambient_temperatures,
         resistance_ohm=tuple(interval_resistance),
+        entropic_coefficient_v_per_k=tuple(interval_entropic_coefficient),
+        irreversible_heat_w=tuple(irreversible_heat),
+        reversible_heat_w=tuple(reversible_heat),
         heat_generation_w=tuple(generated_heat),
         heat_rejection_w=tuple(rejected_heat),
         interval_net_heat_j=tuple(interval_net_heat),
@@ -415,8 +516,11 @@ def write_simulation_csv(path: Path, result: ThermalSimulation) -> None:
         "current_a",
         "ambient_temperature_c",
         "resistance_ohm",
+        "entropic_coefficient_v_per_k",
         "start_temperature_c",
         "end_temperature_c",
+        "irreversible_heat_w",
+        "reversible_heat_w",
         "heat_generation_w",
         "heat_rejection_w",
         "net_heat_j",
@@ -434,8 +538,13 @@ def write_simulation_csv(path: Path, result: ThermalSimulation) -> None:
                 "current_a": current_a,
                 "ambient_temperature_c": result.ambient_temperature_c[index],
                 "resistance_ohm": result.resistance_ohm[index],
+                "entropic_coefficient_v_per_k": (
+                    result.entropic_coefficient_v_per_k[index]
+                ),
                 "start_temperature_c": result.temperature_c[index],
                 "end_temperature_c": result.temperature_c[index + 1],
+                "irreversible_heat_w": result.irreversible_heat_w[index],
+                "reversible_heat_w": result.reversible_heat_w[index],
                 "heat_generation_w": generated_w,
                 "heat_rejection_w": rejected_w,
                 "net_heat_j": result.interval_net_heat_j[index],
@@ -465,6 +574,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         type=float,
         default=25.0,
     )
+    parser.add_argument("--entropic-coefficient-v-per-k", type=float)
     parser.add_argument("--heat-transfer-w-per-k", type=float, default=1.2)
     parser.add_argument("--ambient-temperature-c", type=float)
     parser.add_argument("--initial-temperature-c", type=float, default=25.0)
@@ -482,6 +592,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parse_args(argv)
     ambient_temperatures_c = None
     interval_durations_s = None
+    entropic_coefficients_v_per_k = None
     if args.profile_csv:
         conflicting = [
             name
@@ -500,9 +611,18 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "--ambient-temperature-c cannot be combined with a profile "
                 "that contains ambient_temperature_c"
             )
+        if (
+            profile.entropic_coefficient_v_per_k is not None
+            and args.entropic_coefficient_v_per_k is not None
+        ):
+            raise ValueError(
+                "--entropic-coefficient-v-per-k cannot be combined with a "
+                "profile that contains entropic_coefficient_v_per_k"
+            )
         currents = profile.current_a
         ambient_temperatures_c = profile.ambient_temperature_c
         interval_durations_s = profile.interval_duration_s
+        entropic_coefficients_v_per_k = profile.entropic_coefficient_v_per_k
         time_step_s = profile.time_step_s or profile.interval_duration_s[0]
     else:
         current_a = 75.0 if args.current_a is None else args.current_a
@@ -534,6 +654,11 @@ def main(argv: Sequence[str] | None = None) -> int:
             args.resistance_temperature_coefficient_per_k
         ),
         resistance_reference_temperature_c=(args.resistance_reference_temperature_c),
+        entropic_coefficient_v_per_k=(
+            0.0
+            if args.entropic_coefficient_v_per_k is None
+            else args.entropic_coefficient_v_per_k
+        ),
         heat_transfer_w_per_k=args.heat_transfer_w_per_k,
         ambient_temperature_c=ambient_temperature_c,
         initial_temperature_c=args.initial_temperature_c,
@@ -543,8 +668,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     result = simulate_lumped_temperature(
         currents,
         spec,
-        ambient_temperatures_c,
-        interval_durations_s,
+        ambient_temperatures_c=ambient_temperatures_c,
+        interval_durations_s=interval_durations_s,
+        entropic_coefficients_v_per_k=entropic_coefficients_v_per_k,
     )
 
     if args.output_csv:
@@ -559,6 +685,21 @@ def main(argv: Sequence[str] | None = None) -> int:
         "Resistance range: "
         f"{min(result.resistance_ohm):.6f} to "
         f"{max(result.resistance_ohm):.6f} ohm"
+    )
+    print(
+        "Entropic coefficient range: "
+        f"{min(result.entropic_coefficient_v_per_k):.6g} to "
+        f"{max(result.entropic_coefficient_v_per_k):.6g} V/K"
+    )
+    print(
+        "Reversible heat range: "
+        f"{min(result.reversible_heat_w):.6f} to "
+        f"{max(result.reversible_heat_w):.6f} W"
+    )
+    print(
+        "Total heat-source range: "
+        f"{min(result.heat_generation_w):.6f} to "
+        f"{max(result.heat_generation_w):.6f} W"
     )
     print(f"Stored thermal energy: {result.stored_energy_change_j:.3f} J")
     print(f"Integrated net heat: {result.integrated_net_heat_j:.3f} J")

--- a/notes/heat-generation-model-selection.md
+++ b/notes/heat-generation-model-selection.md
@@ -34,6 +34,6 @@ Use a simple model for learning and quick screening. Move to condition-dependent
 
 The executable reference demonstrates the reversible term with a constant or
 piecewise-constant coefficient. The underlying equation is documented in the
-[NREL Li-Ion Battery Thermal Characterization report](https://www.nrel.gov/docs/fy24osti/89032.pdf).
+[NREL Li-Ion Battery Thermal Characterization paper](https://www.osti.gov/biblio/2349292).
 Use measured coefficients over the applicable SOC and temperature range before
 interpreting the term as cell-specific behavior.

--- a/notes/heat-generation-model-selection.md
+++ b/notes/heat-generation-model-selection.md
@@ -7,7 +7,7 @@ Battery thermal models should use the simplest heat-generation representation th
 | Approach | Typical Form | Best Use | Limits To Document |
 |---|---|---|---|
 | Simple ohmic loss | `Q_dot = I^2 * R` | Early sizing, quick sensitivity checks, education examples. | Resistance value, temperature range, SOC range, pulse duration, and whether charge/discharge asymmetry is ignored. |
-| OCV / entropy-aware heat | Combines irreversible loss with reversible heat such as `I * T * dU/dT`. | Studies where SOC, temperature, or charge/discharge direction changes the thermal response. | Source of OCV curve, source of entropy coefficient, interpolation method, and sign convention. |
+| OCV / entropy-aware heat | Combines irreversible loss with reversible heat such as `-I * T * dU_oc/dT` for the stated positive-discharge convention. | Studies where SOC, temperature, or charge/discharge direction changes the thermal response. | Source of OCV curve, source of entropy coefficient, interpolation method, current direction, and sign convention. |
 | Measured or calorimetry-informed heat | Heat map or fitted model from measured cell behavior. | Design reviews, validation packs, high-power duty cycles, and thermal-management decisions. | Test conditions, cell age, C-rate range, temperature range, measurement uncertainty, and scaling from cell to module or pack. |
 
 ## Selection Guide
@@ -31,3 +31,9 @@ Battery thermal models should use the simplest heat-generation representation th
 ## Practical Rule
 
 Use a simple model for learning and quick screening. Move to condition-dependent or measured heat-generation inputs when the result affects BTMS architecture, safety margin, warranty discussion, or commissioning evidence.
+
+The executable reference demonstrates the reversible term with a constant or
+piecewise-constant coefficient. The underlying equation is documented in the
+[NREL Li-Ion Battery Thermal Characterization report](https://www.nrel.gov/docs/fy24osti/89032.pdf).
+Use measured coefficients over the applicable SOC and temperature range before
+interpreting the term as cell-specific behavior.

--- a/tests/test_lumped_cell_thermal.py
+++ b/tests/test_lumped_cell_thermal.py
@@ -114,6 +114,22 @@ class LumpedCellThermalTests(unittest.TestCase):
         self.assertAlmostEqual(result.temperature_c[-1], 35.0, places=12)
         self.assertAlmostEqual(result.interval_net_heat_j[0], 10_000.0, places=9)
 
+    def test_exact_linear_handles_entropy_cancelling_cooling_slope(self):
+        spec = LumpedThermalSpec(
+            mass_kg=1.0,
+            specific_heat_j_per_kg_k=1000.0,
+            resistance_ohm=0.01,
+            entropic_coefficient_v_per_k=-0.01,
+            heat_transfer_w_per_k=1.0,
+            ambient_temperature_c=25.0,
+            initial_temperature_c=25.0,
+            time_step_s=100.0,
+            integration_method=IntegrationMethod.EXACT_LINEAR,
+        )
+        result = simulate_lumped_temperature([100.0], spec)
+        self.assertAlmostEqual(result.temperature_c[-1], 64.815, places=12)
+        self.assertAlmostEqual(result.interval_net_heat_j[0], 39_815.0, places=9)
+
     def test_discrete_energy_balance_closes(self):
         profile = [80.0] * 300 + [0.0] * 300
         result = simulate_lumped_temperature(profile)
@@ -129,6 +145,89 @@ class LumpedCellThermalTests(unittest.TestCase):
                 for heat_w in result.heat_generation_w
             )
         )
+
+    def test_default_entropic_term_preserves_irreversible_only_behavior(self):
+        result = simulate_lumped_temperature([75.0, -75.0])
+        self.assertEqual(result.entropic_coefficient_v_per_k, (0.0, 0.0))
+        self.assertEqual(result.reversible_heat_w, (0.0, 0.0))
+        self.assertEqual(result.irreversible_heat_w, result.heat_generation_w)
+
+    def test_reversible_heat_changes_sign_with_current_direction(self):
+        spec = LumpedThermalSpec(
+            entropic_coefficient_v_per_k=0.0001,
+            heat_transfer_w_per_k=0.0,
+        )
+        discharge = simulate_lumped_temperature([100.0], spec)
+        charge = simulate_lumped_temperature([-100.0], spec)
+        expected_magnitude_w = 100.0 * (25.0 + 273.15) * 0.0001
+
+        self.assertAlmostEqual(
+            discharge.reversible_heat_w[0],
+            -expected_magnitude_w,
+            places=12,
+        )
+        self.assertAlmostEqual(
+            charge.reversible_heat_w[0],
+            expected_magnitude_w,
+            places=12,
+        )
+        self.assertEqual(discharge.irreversible_heat_w[0], 40.0)
+        self.assertAlmostEqual(
+            discharge.heat_generation_w[0],
+            40.0 - expected_magnitude_w,
+            places=12,
+        )
+        self.assertLess(discharge.temperature_c[-1], charge.temperature_c[-1])
+
+    def test_exact_linear_matches_combined_thermal_feedback_solution(self):
+        spec = LumpedThermalSpec(
+            mass_kg=1.0,
+            specific_heat_j_per_kg_k=1000.0,
+            resistance_ohm=0.01,
+            resistance_temperature_coefficient_per_k=0.01,
+            entropic_coefficient_v_per_k=0.0002,
+            heat_transfer_w_per_k=1.0,
+            ambient_temperature_c=20.0,
+            initial_temperature_c=30.0,
+            time_step_s=600.0,
+            integration_method=IntegrationMethod.EXACT_LINEAR,
+        )
+        current_a = 50.0
+        result = simulate_lumped_temperature([current_a], spec)
+        feedback_w_per_k = (
+            current_a**2
+            * spec.resistance_ohm
+            * spec.resistance_temperature_coefficient_per_k
+            - current_a * spec.entropic_coefficient_v_per_k
+            - spec.heat_transfer_w_per_k
+        )
+        start_net_heat_w = result.heat_generation_w[0] - result.heat_rejection_w[0]
+        expected_change_c = (
+            start_net_heat_w
+            * math.expm1(
+                feedback_w_per_k * spec.time_step_s / spec.thermal_capacity_j_per_k
+            )
+            / feedback_w_per_k
+        )
+        self.assertAlmostEqual(
+            result.temperature_c[-1],
+            spec.initial_temperature_c + expected_change_c,
+            places=12,
+        )
+        self.assertLess(result.energy_balance_error_j, 1e-9)
+
+    def test_interval_entropic_coefficients_override_constant_spec_value(self):
+        result = simulate_lumped_temperature(
+            [80.0, -80.0],
+            LumpedThermalSpec(entropic_coefficient_v_per_k=0.5),
+            entropic_coefficients_v_per_k=[0.0001, -0.0002],
+        )
+        self.assertEqual(
+            result.entropic_coefficient_v_per_k,
+            (0.0001, -0.0002),
+        )
+        self.assertLess(result.reversible_heat_w[0], 0.0)
+        self.assertLess(result.reversible_heat_w[1], 0.0)
 
     def test_temperature_feedback_matches_closed_form_discrete_solution(self):
         spec = LumpedThermalSpec(
@@ -219,6 +318,16 @@ class LumpedCellThermalTests(unittest.TestCase):
                 [10.0],
                 LumpedThermalSpec(integration_method="runge-kutta"),
             )
+        with self.assertRaisesRegex(ValueError, "entropic_coefficient.*finite"):
+            simulate_lumped_temperature(
+                [10.0],
+                LumpedThermalSpec(entropic_coefficient_v_per_k=math.nan),
+            )
+        with self.assertRaisesRegex(ValueError, "above absolute zero"):
+            simulate_lumped_temperature(
+                [10.0],
+                LumpedThermalSpec(initial_temperature_c=-273.15),
+            )
 
     def test_rejects_empty_or_nonfinite_current_profiles(self):
         with self.assertRaisesRegex(ValueError, "at least one interval"):
@@ -237,6 +346,7 @@ class LumpedCellThermalTests(unittest.TestCase):
         self.assertEqual(profile.time_s, (0.0, 60.0, 120.0))
         self.assertEqual(profile.current_a, (0.0, 75.0, -50.0))
         self.assertIsNone(profile.ambient_temperature_c)
+        self.assertIsNone(profile.entropic_coefficient_v_per_k)
         self.assertEqual(profile.time_step_s, 60.0)
         self.assertEqual(profile.interval_duration_s, (60.0, 60.0, 60.0))
 
@@ -268,6 +378,24 @@ class LumpedCellThermalTests(unittest.TestCase):
             profile = load_current_profile(path)
         self.assertEqual(profile.current_a, (0.0, 75.0, -50.0))
         self.assertEqual(profile.ambient_temperature_c, (25.0, 30.0, 35.0))
+
+    def test_loads_profile_with_interval_entropic_coefficients(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "profile.csv"
+            path.write_text(
+                "time_s,current_a,duration_s,ambient_temperature_c,"
+                "entropic_coefficient_v_per_k\n"
+                "0,0,30,25,0.0001\n"
+                "30,75,90,30,-0.0002\n",
+                encoding="utf-8",
+            )
+            profile = load_current_profile(path)
+        self.assertEqual(profile.interval_duration_s, (30.0, 90.0))
+        self.assertEqual(profile.ambient_temperature_c, (25.0, 30.0))
+        self.assertEqual(
+            profile.entropic_coefficient_v_per_k,
+            (0.0001, -0.0002),
+        )
 
     def test_interval_ambient_changes_heat_rejection_and_temperature(self):
         constant = simulate_lumped_temperature([0.0, 0.0])
@@ -322,6 +450,18 @@ class LumpedCellThermalTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "duration values must be positive"):
             simulate_lumped_temperature([10.0], interval_durations_s=[0.0])
 
+    def test_rejects_invalid_entropic_coefficient_profile(self):
+        with self.assertRaisesRegex(ValueError, "one value per current interval"):
+            simulate_lumped_temperature(
+                [10.0, 20.0],
+                entropic_coefficients_v_per_k=[0.0001],
+            )
+        with self.assertRaisesRegex(ValueError, "coefficient values must be finite"):
+            simulate_lumped_temperature(
+                [10.0],
+                entropic_coefficients_v_per_k=[math.nan],
+            )
+
     def test_rejects_invalid_csv_header_and_time_grid(self):
         with tempfile.TemporaryDirectory() as directory:
             path = Path(directory) / "profile.csv"
@@ -363,6 +503,12 @@ class LumpedCellThermalTests(unittest.TestCase):
         self.assertEqual(float(rows[0]["duration_s"]), 1.0)
         self.assertEqual(float(rows[0]["ambient_temperature_c"]), 25.0)
         self.assertEqual(float(rows[0]["resistance_ohm"]), 0.004)
+        self.assertEqual(float(rows[0]["entropic_coefficient_v_per_k"]), 0.0)
+        self.assertEqual(float(rows[0]["reversible_heat_w"]), 0.0)
+        self.assertEqual(
+            float(rows[0]["irreversible_heat_w"]),
+            float(rows[0]["heat_generation_w"]),
+        )
         self.assertAlmostEqual(
             sum(float(row["net_heat_j"]) for row in rows),
             result.integrated_net_heat_j,
@@ -473,6 +619,63 @@ class LumpedCellThermalTests(unittest.TestCase):
         )
         self.assertGreater(upper_resistance, 0.004)
 
+    def test_cli_applies_constant_entropic_coefficient(self):
+        standard_output = io.StringIO()
+        with contextlib.redirect_stdout(standard_output):
+            exit_code = main(
+                [
+                    "--current-a",
+                    "100",
+                    "--duration-s",
+                    "1",
+                    "--entropic-coefficient-v-per-k",
+                    "0.0001",
+                ]
+            )
+        self.assertEqual(exit_code, 0)
+        output = standard_output.getvalue()
+        self.assertIn("Entropic coefficient range: 0.0001 to 0.0001 V/K", output)
+        self.assertIn("Reversible heat range: -2.981500 to -2.981500 W", output)
+
+    def test_cli_runs_entropic_profile_and_exports_heat_components(self):
+        with tempfile.TemporaryDirectory() as directory:
+            profile_path = Path(directory) / "profile.csv"
+            output_path = Path(directory) / "result.csv"
+            profile_path.write_text(
+                "time_s,current_a,duration_s,entropic_coefficient_v_per_k\n"
+                "0,80,60,0.0001\n"
+                "60,-80,60,0.0001\n",
+                encoding="utf-8",
+            )
+            standard_output = io.StringIO()
+            with contextlib.redirect_stdout(standard_output):
+                exit_code = main(
+                    [
+                        "--profile-csv",
+                        str(profile_path),
+                        "--output-csv",
+                        str(output_path),
+                        "--integration-method",
+                        "exact-linear",
+                    ]
+                )
+            with output_path.open("r", encoding="utf-8", newline="") as output_file:
+                rows = list(csv.DictReader(output_file))
+        self.assertEqual(exit_code, 0)
+        self.assertIn(
+            "Entropic coefficient range: 0.0001 to 0.0001 V/K",
+            standard_output.getvalue(),
+        )
+        self.assertIn("Reversible heat range: -", standard_output.getvalue())
+        self.assertLess(float(rows[0]["reversible_heat_w"]), 0.0)
+        self.assertGreater(float(rows[1]["reversible_heat_w"]), 0.0)
+        for row in rows:
+            self.assertAlmostEqual(
+                float(row["heat_generation_w"]),
+                float(row["irreversible_heat_w"]) + float(row["reversible_heat_w"]),
+                places=9,
+            )
+
     def test_cli_reports_exact_linear_integration(self):
         standard_output = io.StringIO()
         with contextlib.redirect_stdout(standard_output):
@@ -545,6 +748,24 @@ class LumpedCellThermalTests(unittest.TestCase):
                         str(profile_path),
                         "--ambient-temperature-c",
                         "20",
+                    ]
+                )
+
+    def test_profile_entropic_coefficient_rejects_constant_override(self):
+        with tempfile.TemporaryDirectory() as directory:
+            profile_path = Path(directory) / "profile.csv"
+            profile_path.write_text(
+                "time_s,current_a,entropic_coefficient_v_per_k\n"
+                "0,0,0.0001\n1,10,0.0001\n",
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(ValueError, "cannot be combined"):
+                main(
+                    [
+                        "--profile-csv",
+                        str(profile_path),
+                        "--entropic-coefficient-v-per-k",
+                        "0.0002",
                     ]
                 )
 


### PR DESCRIPTION
## Summary

- add the reversible Bernardi heat term `-I*T*dU_oc/dT` with an explicit positive-discharge convention
- accept a constant or interval-varying entropic coefficient while preserving separate irreversible, reversible, and total heat traces in the API and CSV export
- retain analytic exact-linear integration when resistance, entropy, cooling, ambient, and current are piecewise constant
- add a source-backed charge/discharge profile, documentation, hosted smoke run, physical validation, and focused regression coverage

## Why

The repository's model-selection guide identifies reversible heat as the next fidelity step for charge/discharge comparisons, but the executable reference previously implemented irreversible `I^2 R` heat only. This closes that documented gap without claiming an internal SOC model: projects can provide measured, externally prepared coefficient schedules.

The sign convention and equation are documented against NREL's Li-Ion Battery Thermal Characterization report.

## Validation

- `python -m unittest discover -s tests -v` (40 tests)
- original 75 A outputs unchanged: `34.309 degC` explicit Euler and `34.305 degC` exact linear
- committed 360-second charge/discharge profile: reversible heat `-2.385200 to 2.405025 W`, final temperature `29.811 degC`, energy-balance error `9.094947e-13 J`
- independent 10,000-profile oracle covering 64,542 intervals: zero temperature and heat-component discrepancy; maximum balance residual `4.366e-11 J`
- Python compilation, Ruff checks and formatting, workflow Prettier, README/model Markdown lint, CSV schema checks, and `git diff --check`