### PR TITLE
Support variable cooling profiles

### DIFF
--- a/.github/workflows/markdown-maintenance.yml
+++ b/.github/workflows/markdown-maintenance.yml
@@ -42,6 +42,13 @@ jobs:
           --integration-method exact-linear
           --output-csv "$RUNNER_TEMP/reversible-heat-intervals.csv"
 
+      - name: Run variable cooling example
+        run: >-
+          python models/lumped_cell_thermal.py
+          --profile-csv models/data/variable_cooling_profile.csv
+          --integration-method exact-linear
+          --output-csv "$RUNNER_TEMP/variable-cooling-intervals.csv"
+
       - name: Check Markdown links
         uses: lycheeverse/lychee-action@v2
         with:

--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ LICENSE
 
 The dependency-free lumped model implements irreversible `I^2 R` heating,
 optional reversible entropic heat, linear resistance-temperature feedback,
-linear heat rejection, explicit Euler or exact linear interval integration,
-and an energy-balance diagnostic:
+piecewise-constant heat-transfer boundaries, explicit Euler or exact linear
+interval integration, and an energy-balance diagnostic:
 
 ```powershell
 python models/lumped_cell_thermal.py --current-a 75 --duration-s 600
@@ -116,14 +116,18 @@ python models/lumped_cell_thermal.py `
   --profile-csv models/data/reversible_heat_current_profile.csv `
   --integration-method exact-linear `
   --output-csv results/reversible_heat_intervals.csv
+python models/lumped_cell_thermal.py `
+  --profile-csv models/data/variable_cooling_profile.csv `
+  --integration-method exact-linear `
+  --output-csv results/variable_cooling_intervals.csv
 python -m unittest discover -s tests -v
 ```
 
 See the [model assumptions and limitations](models/README.md) before adapting
 the parameters or using the output in an engineering review. The profile path
 supports traceable charge/discharge duty cycles, optional interval ambient
-temperature and entropic coefficients, explicit nonuniform interval durations,
-and interval-level CSV results.
+temperature, entropic coefficients, and heat-transfer coefficients, explicit
+nonuniform interval durations, and interval-level CSV results.
 
 ## Contribution Entry Points
 

--- a/models/README.md
+++ b/models/README.md
@@ -14,15 +14,16 @@ Q_irreversible = I^2 R
 Q_reversible = -I T_kelvin dU_oc/dT
 Q_generation = Q_irreversible + Q_reversible
 R(T) = R_ref [1 + alpha (T_cell - T_ref)]
-Q_rejection = h (T_cell - T_ambient)
+Q_rejection = h(t) (T_cell - T_ambient)
 C_thermal dT/dt = Q_generation - Q_rejection
 C_thermal = mass * specific_heat
 ```
 
 The default method advances temperature with an explicit Euler step. The
-optional exact linear method solves each piecewise-constant interval
-analytically. The returned result includes stored thermal energy, integrated
-net heat, and their absolute difference so discretization and implementation
+optional exact linear method solves each interval analytically when current,
+ambient, entropic coefficient, and heat-transfer coefficient are piecewise
+constant. The returned result includes stored thermal energy, integrated net
+heat, and their absolute difference so discretization and implementation
 changes can be audited.
 
 ## Run The Reference Case
@@ -60,7 +61,8 @@ python models/lumped_cell_thermal.py `
 
 With constant current, ambient, and entropic coefficient over an interval,
 linear heat rejection, reversible heat, and the configured linear
-resistance-temperature relation produce a linear ODE.
+resistance-temperature relation produce a linear ODE. An interval-specific
+heat-transfer coefficient is included in that interval's exact feedback slope.
 The exact method evaluates its exponential solution with `expm1` for numerical
 stability. It also stores the exact net interval heat as thermal capacity times
 the temperature change. CSV heat rates, `resistance_ohm`, and
@@ -75,7 +77,8 @@ comparisons or backward-compatible result reproduction.
 ## Run A Current And Ambient Profile
 
 The CLI accepts a strict CSV containing interval-start timestamps and current
-commands, with optional interval duration and ambient-temperature columns.
+commands, with optional interval duration, ambient temperature, entropic
+coefficient, and heat-transfer coefficient columns.
 Without a `duration_s` column, timestamps must start at zero and use one
 uniform step; positive and negative currents both produce irreversible `I^2 R`
 heat.
@@ -96,9 +99,9 @@ python models/lumped_cell_thermal.py `
 ```
 
 The output records interval boundaries and duration, current, start/end
-temperature, ambient temperature, evaluated resistance, entropic coefficient,
-irreversible, reversible, total generated and rejected heat rates, and net
-interval heat.
+temperature, ambient temperature, heat-transfer coefficient, evaluated
+resistance, entropic coefficient, irreversible, reversible, total generated
+and rejected heat rates, and net interval heat.
 Profile mode derives the time step from the CSV and rejects `--current-a`,
 `--duration-s`, or `--time-step-s` overrides.
 
@@ -140,6 +143,41 @@ The Python API accepts the same schedule through `interval_durations_s`. The
 simulation exposes every interval duration, cumulative time boundaries, and
 the total elapsed duration. Its `time_step_s` compatibility property returns
 the common duration for a uniform grid and `None` for a variable grid.
+
+## Variable Cooling Boundary
+
+Add `heat_transfer_w_per_k` to a profile to represent a supplied sequence of
+effective cooling conditions such as staged airflow, coolant-flow operating
+points, or conservative sensitivity cases:
+
+```csv
+time_s,current_a,duration_s,ambient_temperature_c,heat_transfer_w_per_k
+0,100,300,35,0.6
+300,100,300,35,1.2
+600,100,300,35,4.0
+900,50,300,30,6.0
+1200,0,600,25,6.0
+```
+
+Run the committed staged-cooling example with exact integration:
+
+```powershell
+python models/lumped_cell_thermal.py `
+  --profile-csv models/data/variable_cooling_profile.csv `
+  --integration-method exact-linear `
+  --output-csv results/variable_cooling_intervals.csv
+```
+
+The Python API accepts the same values through `heat_transfers_w_per_k`. Values
+must be finite and nonnegative. A profile column takes precedence over the
+constant boundary, so combining it with `--heat-transfer-w-per-k` is rejected
+instead of silently choosing one source. Every interval result and exported row
+preserves the applied value.
+
+This input is an effective conductance boundary, not a fan, pump, coolant-loop,
+or feedback-controller model. Step changes occur only at supplied interval
+boundaries; derive values from measurements, correlations, or a separately
+validated cooling model before drawing design conclusions.
 
 ## Reversible Entropic Heat
 
@@ -211,14 +249,16 @@ window before engineering use.
   coefficient; the model does not derive its SOC or chemistry dependence.
 - Mixing, phase-change, side-reaction, and interconnect heat are excluded.
 - The cell is represented by one uniform temperature state.
-- Heat transfer is linear; ambient may vary by interval, but the heat-transfer
-  coefficient remains fixed.
+- Heat transfer is linear; ambient and the effective heat-transfer coefficient
+  may vary by interval, but fluid dynamics, coolant thermal mass, actuator
+  dynamics, and feedback control are not represented.
 - Electrical SOC and voltage dynamics are outside this reference model.
 - Parameters are educational placeholders and require sourced replacement for
   engineering decisions.
 - Current-profile timestamps are treated as interval starts with piecewise
-  constant current and ambient temperature over each interval. Explicit
-  durations may vary, but the model does not interpolate within an interval.
+  constant current, ambient temperature, coefficients, and heat transfer over
+  each interval. Explicit durations may vary, but the model does not interpolate
+  within an interval.
 - Exact integration applies only to the model's linear within-interval
   equation; nonlinear resistance maps or radiation would require a different
   solver.

--- a/models/data/variable_cooling_profile.csv
+++ b/models/data/variable_cooling_profile.csv
@@ -1,0 +1,6 @@
+time_s,current_a,duration_s,ambient_temperature_c,heat_transfer_w_per_k
+0,100,300,35,0.6
+300,100,300,35,1.2
+600,100,300,35,4.0
+900,50,300,30,6.0
+1200,0,600,25,6.0

--- a/models/lumped_cell_thermal.py
+++ b/models/lumped_cell_thermal.py
@@ -128,6 +128,7 @@ class ThermalSimulation:
     temperature_c: tuple[float, ...]
     current_a: tuple[float, ...]
     ambient_temperature_c: tuple[float, ...]
+    heat_transfer_w_per_k: tuple[float, ...]
     resistance_ohm: tuple[float, ...]
     entropic_coefficient_v_per_k: tuple[float, ...]
     irreversible_heat_w: tuple[float, ...]
@@ -181,12 +182,13 @@ class ThermalSimulation:
 
 @dataclass(frozen=True)
 class CurrentProfile:
-    """Interval starts, durations, current, ambient, and entropic coefficients."""
+    """Piecewise-constant electrical and thermal boundary conditions."""
 
     time_s: tuple[float, ...]
     current_a: tuple[float, ...]
     ambient_temperature_c: tuple[float, ...] | None
     entropic_coefficient_v_per_k: tuple[float, ...] | None
+    heat_transfer_w_per_k: tuple[float, ...] | None
     interval_duration_s: tuple[float, ...]
 
     @property
@@ -216,7 +218,7 @@ def _temperature_k(temperature_c: float, context: str) -> float:
 
 
 def load_current_profile(path: Path) -> CurrentProfile:
-    """Load current, duration, ambient, and entropic-coefficient intervals."""
+    """Load piecewise-constant electrical and thermal profile intervals."""
 
     with path.open("r", encoding="utf-8", newline="") as profile_file:
         reader = csv.DictReader(profile_file)
@@ -225,6 +227,7 @@ def load_current_profile(path: Path) -> CurrentProfile:
             "duration_s",
             "ambient_temperature_c",
             "entropic_coefficient_v_per_k",
+            "heat_transfer_w_per_k",
         ]
         fieldnames = reader.fieldnames or []
         selected_optional_headers = [
@@ -237,11 +240,12 @@ def load_current_profile(path: Path) -> CurrentProfile:
             raise ValueError(
                 "profile CSV header must be exactly time_s,current_a followed by "
                 "any of duration_s,ambient_temperature_c,"
-                "entropic_coefficient_v_per_k in that order"
+                "entropic_coefficient_v_per_k,heat_transfer_w_per_k in that order"
             )
         has_ambient = "ambient_temperature_c" in fieldnames
         has_duration = "duration_s" in fieldnames
         has_entropic_coefficient = "entropic_coefficient_v_per_k" in fieldnames
+        has_heat_transfer = "heat_transfer_w_per_k" in fieldnames
         rows = list(reader)
 
     if not rows:
@@ -254,6 +258,7 @@ def load_current_profile(path: Path) -> CurrentProfile:
     durations: list[float] = []
     ambient_temperatures: list[float] = []
     entropic_coefficients: list[float] = []
+    heat_transfers: list[float] = []
     for line_number, row in enumerate(rows, start=2):
         try:
             time_s = float(row["time_s"])
@@ -267,6 +272,9 @@ def load_current_profile(path: Path) -> CurrentProfile:
                 if has_entropic_coefficient
                 else None
             )
+            heat_transfer_w_per_k = (
+                float(row["heat_transfer_w_per_k"]) if has_heat_transfer else None
+            )
         except (TypeError, ValueError) as error:
             raise ValueError(
                 f"profile CSV line {line_number} must contain numeric values"
@@ -278,11 +286,18 @@ def load_current_profile(path: Path) -> CurrentProfile:
             values.append(ambient_temperature_c)
         if entropic_coefficient_v_per_k is not None:
             values.append(entropic_coefficient_v_per_k)
+        if heat_transfer_w_per_k is not None:
+            values.append(heat_transfer_w_per_k)
         if None in row or any(not math.isfinite(value) for value in values):
             raise ValueError(f"profile CSV line {line_number} must be finite")
         if duration_s is not None and duration_s <= 0.0:
             raise ValueError(
                 f"profile CSV line {line_number} duration_s must be positive"
+            )
+        if heat_transfer_w_per_k is not None and heat_transfer_w_per_k < 0.0:
+            raise ValueError(
+                f"profile CSV line {line_number} heat_transfer_w_per_k "
+                "must be nonnegative"
             )
         times.append(time_s)
         currents.append(current_a)
@@ -296,6 +311,8 @@ def load_current_profile(path: Path) -> CurrentProfile:
             ambient_temperatures.append(ambient_temperature_c)
         if entropic_coefficient_v_per_k is not None:
             entropic_coefficients.append(entropic_coefficient_v_per_k)
+        if heat_transfer_w_per_k is not None:
+            heat_transfers.append(heat_transfer_w_per_k)
 
     if not math.isclose(times[0], 0.0, rel_tol=0.0, abs_tol=1e-12):
         raise ValueError("profile CSV time_s must start at zero")
@@ -342,6 +359,7 @@ def load_current_profile(path: Path) -> CurrentProfile:
         entropic_coefficient_v_per_k=(
             tuple(entropic_coefficients) if has_entropic_coefficient else None
         ),
+        heat_transfer_w_per_k=(tuple(heat_transfers) if has_heat_transfer else None),
         interval_duration_s=tuple(durations),
     )
 
@@ -352,6 +370,7 @@ def simulate_lumped_temperature(
     ambient_temperatures_c: Sequence[float] | None = None,
     interval_durations_s: Sequence[float] | None = None,
     entropic_coefficients_v_per_k: Sequence[float] | None = None,
+    heat_transfers_w_per_k: Sequence[float] | None = None,
 ) -> ThermalSimulation:
     """Integrate a one-node thermal balance over piecewise-constant intervals."""
 
@@ -405,6 +424,19 @@ def simulate_lumped_temperature(
         if any(not math.isfinite(value) for value in entropic_coefficients):
             raise ValueError("all entropic coefficient values must be finite")
 
+    if heat_transfers_w_per_k is None:
+        heat_transfers = (spec.heat_transfer_w_per_k,) * len(currents)
+    else:
+        heat_transfers = tuple(float(value) for value in heat_transfers_w_per_k)
+        if len(heat_transfers) != len(currents):
+            raise ValueError(
+                "heat_transfers_w_per_k must contain one value per current interval"
+            )
+        if any(not math.isfinite(value) for value in heat_transfers):
+            raise ValueError("all heat transfer values must be finite")
+        if any(value < 0.0 for value in heat_transfers):
+            raise ValueError("all heat transfer values must be nonnegative")
+
     temperatures = [spec.initial_temperature_c]
     irreversible_heat: list[float] = []
     reversible_heat: list[float] = []
@@ -419,11 +451,13 @@ def simulate_lumped_temperature(
         ambient_temperature_c,
         interval_duration_s,
         entropic_coefficient_v_per_k,
+        heat_transfer_w_per_k,
     ) in zip(
         currents,
         ambient_temperatures,
         interval_durations,
         entropic_coefficients,
+        heat_transfers,
         strict=True,
     ):
         temperature = temperatures[-1]
@@ -435,7 +469,7 @@ def simulate_lumped_temperature(
             entropic_coefficient_v_per_k,
         )
         generation_w = irreversible_w + reversible_w
-        rejection_w = spec.heat_transfer_w_per_k * (temperature - ambient_temperature_c)
+        rejection_w = heat_transfer_w_per_k * (temperature - ambient_temperature_c)
         net_heat_w = generation_w - rejection_w
         if integration_method is IntegrationMethod.EXPLICIT_EULER:
             temperature_change_c = (
@@ -448,7 +482,7 @@ def simulate_lumped_temperature(
                 * spec.resistance_ohm
                 * spec.resistance_temperature_coefficient_per_k
                 - current * entropic_coefficient_v_per_k
-                - spec.heat_transfer_w_per_k
+                - heat_transfer_w_per_k
             )
             if thermal_feedback_w_per_k == 0.0:
                 temperature_change_c = (
@@ -492,6 +526,7 @@ def simulate_lumped_temperature(
         temperature_c=tuple(temperatures),
         current_a=currents,
         ambient_temperature_c=ambient_temperatures,
+        heat_transfer_w_per_k=heat_transfers,
         resistance_ohm=tuple(interval_resistance),
         entropic_coefficient_v_per_k=tuple(interval_entropic_coefficient),
         irreversible_heat_w=tuple(irreversible_heat),
@@ -515,6 +550,7 @@ def write_simulation_csv(path: Path, result: ThermalSimulation) -> None:
         "duration_s",
         "current_a",
         "ambient_temperature_c",
+        "heat_transfer_w_per_k",
         "resistance_ohm",
         "entropic_coefficient_v_per_k",
         "start_temperature_c",
@@ -537,6 +573,7 @@ def write_simulation_csv(path: Path, result: ThermalSimulation) -> None:
                 "duration_s": result.interval_duration_s[index],
                 "current_a": current_a,
                 "ambient_temperature_c": result.ambient_temperature_c[index],
+                "heat_transfer_w_per_k": result.heat_transfer_w_per_k[index],
                 "resistance_ohm": result.resistance_ohm[index],
                 "entropic_coefficient_v_per_k": (
                     result.entropic_coefficient_v_per_k[index]
@@ -575,7 +612,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         default=25.0,
     )
     parser.add_argument("--entropic-coefficient-v-per-k", type=float)
-    parser.add_argument("--heat-transfer-w-per-k", type=float, default=1.2)
+    parser.add_argument("--heat-transfer-w-per-k", type=float)
     parser.add_argument("--ambient-temperature-c", type=float)
     parser.add_argument("--initial-temperature-c", type=float, default=25.0)
     parser.add_argument("--mass-kg", type=float, default=1.05)
@@ -593,6 +630,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     ambient_temperatures_c = None
     interval_durations_s = None
     entropic_coefficients_v_per_k = None
+    heat_transfers_w_per_k = None
     if args.profile_csv:
         conflicting = [
             name
@@ -619,10 +657,19 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "--entropic-coefficient-v-per-k cannot be combined with a "
                 "profile that contains entropic_coefficient_v_per_k"
             )
+        if (
+            profile.heat_transfer_w_per_k is not None
+            and args.heat_transfer_w_per_k is not None
+        ):
+            raise ValueError(
+                "--heat-transfer-w-per-k cannot be combined with a profile "
+                "that contains heat_transfer_w_per_k"
+            )
         currents = profile.current_a
         ambient_temperatures_c = profile.ambient_temperature_c
         interval_durations_s = profile.interval_duration_s
         entropic_coefficients_v_per_k = profile.entropic_coefficient_v_per_k
+        heat_transfers_w_per_k = profile.heat_transfer_w_per_k
         time_step_s = profile.time_step_s or profile.interval_duration_s[0]
     else:
         current_a = 75.0 if args.current_a is None else args.current_a
@@ -659,7 +706,9 @@ def main(argv: Sequence[str] | None = None) -> int:
             if args.entropic_coefficient_v_per_k is None
             else args.entropic_coefficient_v_per_k
         ),
-        heat_transfer_w_per_k=args.heat_transfer_w_per_k,
+        heat_transfer_w_per_k=(
+            1.2 if args.heat_transfer_w_per_k is None else args.heat_transfer_w_per_k
+        ),
         ambient_temperature_c=ambient_temperature_c,
         initial_temperature_c=args.initial_temperature_c,
         time_step_s=time_step_s,
@@ -671,6 +720,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         ambient_temperatures_c=ambient_temperatures_c,
         interval_durations_s=interval_durations_s,
         entropic_coefficients_v_per_k=entropic_coefficients_v_per_k,
+        heat_transfers_w_per_k=heat_transfers_w_per_k,
     )
 
     if args.output_csv:
@@ -685,6 +735,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         "Resistance range: "
         f"{min(result.resistance_ohm):.6f} to "
         f"{max(result.resistance_ohm):.6f} ohm"
+    )
+    print(
+        "Heat-transfer range: "
+        f"{min(result.heat_transfer_w_per_k):.6g} to "
+        f"{max(result.heat_transfer_w_per_k):.6g} W/K"
     )
     print(
         "Entropic coefficient range: "

--- a/notes/thermal-model-limitations.md
+++ b/notes/thermal-model-limitations.md
@@ -8,7 +8,7 @@ Early-stage battery thermal models are useful for learning, screening, and revie
 | Contact resistance omitted | Cell-to-module, module-to-plate, or interface gaps can create gradients that the model does not predict. | Add contact assumptions or sensitivity cases when gradients matter. |
 | Aging not represented | Resistance, capacity, and heat generation may shift as the cell ages. | State age/SOH assumptions and avoid using fresh-cell values for lifetime claims. |
 | Ambient assumption too narrow | A single ambient value can hide hot-day, cold-start, enclosure, or ventilation limits. | Run ambient sensitivity cases or define the approved operating range. |
-| Cooling boundary simplified | Fixed convection or ideal cooling can overstate thermal performance. | Document airflow, coolant, inlet temperature, flow rate, and heat-transfer coefficient sources. |
+| Cooling boundary simplified | Fixed or prescribed convection can overstate thermal performance and miss actuator or fluid transients. | Document airflow, coolant, inlet temperature, flow rate, and heat-transfer coefficient sources; run bounded coefficient schedules when staged cooling matters. |
 | Module/pack scaling simplified | Cell-level heat results may not capture interconnects, busbars, spacing, or enclosure behavior. | State scaling assumptions and add module or pack evidence before design review. |
 | Validation gap | A visually plausible plot may not match measured pulse, calorimetry, or datasheet behavior. | Include validation reference, confidence level, and known mismatch. |
 | Solver/time-step sensitivity | Coarse time steps can hide transient peaks or numerical instability. | Report solver, time step, and convergence or sensitivity checks. |

--- a/tests/test_lumped_cell_thermal.py
+++ b/tests/test_lumped_cell_thermal.py
@@ -229,6 +229,30 @@ class LumpedCellThermalTests(unittest.TestCase):
         self.assertLess(result.reversible_heat_w[0], 0.0)
         self.assertLess(result.reversible_heat_w[1], 0.0)
 
+    def test_interval_heat_transfer_drives_exact_cooling_solution(self):
+        spec = LumpedThermalSpec(
+            mass_kg=1.0,
+            specific_heat_j_per_kg_k=1000.0,
+            heat_transfer_w_per_k=0.5,
+            ambient_temperature_c=20.0,
+            initial_temperature_c=40.0,
+            integration_method=IntegrationMethod.EXACT_LINEAR,
+        )
+        result = simulate_lumped_temperature(
+            [0.0],
+            spec,
+            interval_durations_s=[300.0],
+            heat_transfers_w_per_k=[4.0],
+        )
+        expected_temperature_c = 20.0 + 20.0 * math.exp(-4.0 * 300.0 / 1000.0)
+        self.assertEqual(result.heat_transfer_w_per_k, (4.0,))
+        self.assertAlmostEqual(
+            result.temperature_c[-1],
+            expected_temperature_c,
+            places=12,
+        )
+        self.assertLess(result.energy_balance_error_j, 1e-9)
+
     def test_temperature_feedback_matches_closed_form_discrete_solution(self):
         spec = LumpedThermalSpec(
             mass_kg=1.0,
@@ -397,6 +421,21 @@ class LumpedCellThermalTests(unittest.TestCase):
             (0.0001, -0.0002),
         )
 
+    def test_loads_profile_with_interval_heat_transfer(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "profile.csv"
+            path.write_text(
+                "time_s,current_a,duration_s,ambient_temperature_c,"
+                "heat_transfer_w_per_k\n"
+                "0,100,300,35,0.6\n"
+                "300,100,300,35,4.0\n",
+                encoding="utf-8",
+            )
+            profile = load_current_profile(path)
+        self.assertEqual(profile.interval_duration_s, (300.0, 300.0))
+        self.assertEqual(profile.ambient_temperature_c, (35.0, 35.0))
+        self.assertEqual(profile.heat_transfer_w_per_k, (0.6, 4.0))
+
     def test_interval_ambient_changes_heat_rejection_and_temperature(self):
         constant = simulate_lumped_temperature([0.0, 0.0])
         warming = simulate_lumped_temperature(
@@ -462,6 +501,32 @@ class LumpedCellThermalTests(unittest.TestCase):
                 entropic_coefficients_v_per_k=[math.nan],
             )
 
+    def test_rejects_invalid_heat_transfer_profile(self):
+        with self.assertRaisesRegex(ValueError, "one value per current interval"):
+            simulate_lumped_temperature(
+                [10.0, 20.0],
+                heat_transfers_w_per_k=[1.0],
+            )
+        with self.assertRaisesRegex(ValueError, "transfer values must be finite"):
+            simulate_lumped_temperature(
+                [10.0],
+                heat_transfers_w_per_k=[math.nan],
+            )
+        with self.assertRaisesRegex(ValueError, "must be nonnegative"):
+            simulate_lumped_temperature(
+                [10.0],
+                heat_transfers_w_per_k=[-0.1],
+            )
+
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "profile.csv"
+            path.write_text(
+                "time_s,current_a,heat_transfer_w_per_k\n0,0,-0.1\n1,0,1.0\n",
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(ValueError, "must be nonnegative"):
+                load_current_profile(path)
+
     def test_rejects_invalid_csv_header_and_time_grid(self):
         with tempfile.TemporaryDirectory() as directory:
             path = Path(directory) / "profile.csv"
@@ -502,6 +567,7 @@ class LumpedCellThermalTests(unittest.TestCase):
         self.assertEqual(float(rows[0]["current_a"]), 50.0)
         self.assertEqual(float(rows[0]["duration_s"]), 1.0)
         self.assertEqual(float(rows[0]["ambient_temperature_c"]), 25.0)
+        self.assertEqual(float(rows[0]["heat_transfer_w_per_k"]), 1.2)
         self.assertEqual(float(rows[0]["resistance_ohm"]), 0.004)
         self.assertEqual(float(rows[0]["entropic_coefficient_v_per_k"]), 0.0)
         self.assertEqual(float(rows[0]["reversible_heat_w"]), 0.0)
@@ -676,6 +742,43 @@ class LumpedCellThermalTests(unittest.TestCase):
                 places=9,
             )
 
+    def test_cli_runs_variable_cooling_profile_and_exports_boundary(self):
+        with tempfile.TemporaryDirectory() as directory:
+            profile_path = Path(directory) / "profile.csv"
+            output_path = Path(directory) / "result.csv"
+            profile_path.write_text(
+                "time_s,current_a,duration_s,ambient_temperature_c,"
+                "heat_transfer_w_per_k\n"
+                "0,100,300,35,0.6\n"
+                "300,100,300,35,4.0\n"
+                "600,0,300,25,6.0\n",
+                encoding="utf-8",
+            )
+            standard_output = io.StringIO()
+            with contextlib.redirect_stdout(standard_output):
+                exit_code = main(
+                    [
+                        "--profile-csv",
+                        str(profile_path),
+                        "--output-csv",
+                        str(output_path),
+                        "--integration-method",
+                        "exact-linear",
+                    ]
+                )
+            with output_path.open("r", encoding="utf-8", newline="") as output_file:
+                rows = list(csv.DictReader(output_file))
+        self.assertEqual(exit_code, 0)
+        self.assertIn(
+            "Heat-transfer range: 0.6 to 6 W/K",
+            standard_output.getvalue(),
+        )
+        self.assertEqual(
+            [float(row["heat_transfer_w_per_k"]) for row in rows],
+            [0.6, 4.0, 6.0],
+        )
+        self.assertLess(float(rows[-1]["end_temperature_c"]), 35.0)
+
     def test_cli_reports_exact_linear_integration(self):
         standard_output = io.StringIO()
         with contextlib.redirect_stdout(standard_output):
@@ -768,6 +871,52 @@ class LumpedCellThermalTests(unittest.TestCase):
                         "0.0002",
                     ]
                 )
+
+    def test_profile_heat_transfer_rejects_constant_override(self):
+        with tempfile.TemporaryDirectory() as directory:
+            profile_path = Path(directory) / "profile.csv"
+            profile_path.write_text(
+                "time_s,current_a,heat_transfer_w_per_k\n0,0,1.0\n1,10,2.0\n",
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(ValueError, "cannot be combined"):
+                main(
+                    [
+                        "--profile-csv",
+                        str(profile_path),
+                        "--heat-transfer-w-per-k",
+                        "3.0",
+                    ]
+                )
+
+    def test_profile_without_heat_transfer_uses_constant_override(self):
+        with tempfile.TemporaryDirectory() as directory:
+            profile_path = Path(directory) / "profile.csv"
+            output_path = Path(directory) / "result.csv"
+            profile_path.write_text(
+                "time_s,current_a\n0,0\n1,10\n",
+                encoding="utf-8",
+            )
+            with contextlib.redirect_stdout(io.StringIO()):
+                self.assertEqual(
+                    main(
+                        [
+                            "--profile-csv",
+                            str(profile_path),
+                            "--heat-transfer-w-per-k",
+                            "3.0",
+                            "--output-csv",
+                            str(output_path),
+                        ]
+                    ),
+                    0,
+                )
+            with output_path.open("r", encoding="utf-8", newline="") as output_file:
+                rows = list(csv.DictReader(output_file))
+        self.assertEqual(
+            [float(row["heat_transfer_w_per_k"]) for row in rows],
+            [3.0, 3.0],
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- accept interval-varying effective heat-transfer coefficients through the Python API and strict profile CSVs
- apply each cooling boundary in explicit Euler and exact-linear integration, exports, and CLI diagnostics
- add a staged-cooling reference profile, hosted workflow coverage, documented assumptions, and regression tests

## Validation

- python -m unittest discover -s tests -v (46 tests)
- uff check models tests
- uff format --check models tests
- committed variable-cooling CLI example (peak 46.150 degC, final 25.296 degC, energy-balance error 2.39e-12 J)
- Markdown lint for README and model guide; Prettier workflow check
- 37 affected-document links checked successfully
- independent 10,000-case exact-versus-RK4 oracle (maximum temperature discrepancy 4.33e-08 degC; zero default-boundary drift)
