### PR TITLE
Add external heat-source profiles

### DIFF
--- a/.github/workflows/markdown-maintenance.yml
+++ b/.github/workflows/markdown-maintenance.yml
@@ -49,6 +49,13 @@ jobs:
           --integration-method exact-linear
           --output-csv "$RUNNER_TEMP/variable-cooling-intervals.csv"
 
+      - name: Run external heat-source example
+        run: >-
+          python models/lumped_cell_thermal.py
+          --profile-csv models/data/external_heat_profile.csv
+          --integration-method exact-linear
+          --output-csv "$RUNNER_TEMP/external-heat-intervals.csv"
+
       - name: Run radiative surroundings example
         run: >-
           python models/lumped_cell_thermal.py

--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ LICENSE
 ## Run The Executable Reference
 
 The dependency-free lumped model implements irreversible `I^2 R` heating,
-optional reversible entropic heat, linear resistance-temperature feedback,
+optional reversible entropic heat, a signed external heat-source profile,
+linear resistance-temperature feedback,
 piecewise-constant convection, an independently schedulable radiative
 surroundings boundary, optional nonlinear surface radiation, explicit Euler,
 exact linear, or bounded-step RK4 integration, and an energy-balance diagnostic:
@@ -122,6 +123,10 @@ python models/lumped_cell_thermal.py `
   --integration-method exact-linear `
   --output-csv results/variable_cooling_intervals.csv
 python models/lumped_cell_thermal.py `
+  --profile-csv models/data/external_heat_profile.csv `
+  --integration-method exact-linear `
+  --output-csv results/external_heat_intervals.csv
+python models/lumped_cell_thermal.py `
   --profile-csv models/data/radiative_cooling_profile.csv `
   --emissivity 0.85 --radiating-area-m2 0.03 `
   --integration-method rk4 --rk4-max-step-s 0.5 `
@@ -133,8 +138,9 @@ See the [model assumptions and limitations](models/README.md) before adapting
 the parameters or using the output in an engineering review. The profile path
 supports traceable charge/discharge duty cycles, optional interval ambient
 and radiative-surroundings temperatures, entropic coefficients, and
-heat-transfer coefficients, explicit nonuniform interval durations, optional
-diffuse-gray radiation, and interval-level CSV results.
+external heat sources and heat-transfer coefficients, explicit nonuniform
+interval durations, optional diffuse-gray radiation, and interval-level CSV
+results.
 
 ## Contribution Entry Points
 

--- a/models/README.md
+++ b/models/README.md
@@ -12,7 +12,7 @@ For each time interval, the model evaluates:
 ```text
 Q_irreversible = I^2 R
 Q_reversible = -I T_kelvin dU_oc/dT
-Q_generation = Q_irreversible + Q_reversible
+Q_generation = Q_irreversible + Q_reversible + Q_external
 R(T) = R_ref [1 + alpha (T_cell - T_ref)]
 Q_convection = h(t) (T_cell - T_ambient)
 Q_radiation = epsilon sigma A (T_cell_kelvin^4 - T_surroundings_kelvin^4)
@@ -293,13 +293,46 @@ temperature is rejected. Replace the reference resistance, coefficient, and
 temperature with values fitted or measured for the target cell and operating
 window before engineering use.
 
+## External Heat-Source Profile
+
+Use `--external-heat-w` for a constant signed heat flow into the lumped node,
+or add `external_heat_w` to a current-profile CSV for a piecewise-constant
+schedule. Positive values add heat; negative values represent an independently
+specified heat sink. This can represent a controlled heater, neighboring
+component, interconnect estimate, or calibrated parasitic source without
+folding that term into electrical resistance.
+
+Run the committed profile through the exact linear integrator:
+
+```powershell
+python models/lumped_cell_thermal.py `
+  --profile-csv models/data/external_heat_profile.csv `
+  --integration-method exact-linear `
+  --output-csv results/external_heat_intervals.csv
+```
+
+The exported `external_heat_w` column remains separate from irreversible and
+reversible heat. `heat_generation_w` is their signed sum, and `net_heat_j`
+continues to close the stored thermal-energy balance for explicit Euler, exact
+linear, and RK4 integration. A profile source takes precedence over the default
+zero source; combining a profile column with `--external-heat-w` is rejected so
+the boundary condition remains unambiguous.
+
+This input is a prescribed source, not a conduction network or a solved heater
+controller. Its sign, location, time alignment, and physical basis must be
+documented before engineering use. A negative source can remove more heat than
+the electrical terms generate, but it does not enforce coolant, surface, or
+absolute-temperature constraints beyond the model's existing validation.
+
 ## Explicit Limitations
 
 - Resistance may use an optional linear temperature coefficient, but it does
   not vary with SOC or age and does not represent a nonlinear measured map.
 - Reversible heat uses a supplied constant or piecewise-constant entropic
   coefficient; the model does not derive its SOC or chemistry dependence.
-- Mixing, phase-change, side-reaction, and interconnect heat are excluded.
+- External heat is prescribed rather than derived from a neighboring thermal
+  node, heater controller, or interconnect model.
+- Mixing, phase-change, and side-reaction heat are excluded.
 - The cell is represented by one uniform temperature state.
 - Convection is linear; optional diffuse-gray radiation uses constant surface
   emissivity and area with ambient as the radiative-surroundings temperature.

--- a/models/data/external_heat_profile.csv
+++ b/models/data/external_heat_profile.csv
@@ -1,0 +1,4 @@
+time_s,current_a,duration_s,external_heat_w
+0,0,120,12
+120,0,60,-4
+180,50,120,0

--- a/models/lumped_cell_thermal.py
+++ b/models/lumped_cell_thermal.py
@@ -29,6 +29,7 @@ class LumpedThermalSpec:
     resistance_temperature_coefficient_per_k: float = 0.0
     resistance_reference_temperature_c: float = 25.0
     entropic_coefficient_v_per_k: float = 0.0
+    external_heat_w: float = 0.0
     heat_transfer_w_per_k: float = 1.2
     emissivity: float = 0.0
     radiating_area_m2: float = 0.0
@@ -62,6 +63,7 @@ class LumpedThermalSpec:
                 self.resistance_reference_temperature_c
             ),
             "entropic_coefficient_v_per_k": self.entropic_coefficient_v_per_k,
+            "external_heat_w": self.external_heat_w,
             "heat_transfer_w_per_k": self.heat_transfer_w_per_k,
             "emissivity": self.emissivity,
             "radiating_area_m2": self.radiating_area_m2,
@@ -194,6 +196,7 @@ class ThermalSimulation:
     heat_transfer_w_per_k: tuple[float, ...]
     resistance_ohm: tuple[float, ...]
     entropic_coefficient_v_per_k: tuple[float, ...]
+    external_heat_w: tuple[float, ...]
     irreversible_heat_w: tuple[float, ...]
     reversible_heat_w: tuple[float, ...]
     heat_generation_w: tuple[float, ...]
@@ -257,6 +260,7 @@ class CurrentProfile:
     ambient_temperature_c: tuple[float, ...] | None
     radiative_surroundings_temperature_c: tuple[float, ...] | None
     entropic_coefficient_v_per_k: tuple[float, ...] | None
+    external_heat_w: tuple[float, ...] | None
     heat_transfer_w_per_k: tuple[float, ...] | None
     interval_duration_s: tuple[float, ...]
 
@@ -285,6 +289,7 @@ class HeatRates:
     resistance_ohm: float
     irreversible_w: float
     reversible_w: float
+    external_w: float
     generation_w: float
     convective_rejection_w: float
     radiative_rejection_w: float
@@ -307,6 +312,7 @@ def _heat_rates(
     ambient_temperature_c: float,
     radiative_surroundings_temperature_c: float,
     entropic_coefficient_v_per_k: float,
+    external_heat_w: float,
     heat_transfer_w_per_k: float,
 ) -> HeatRates:
     resistance_ohm = spec.resistance_at_temperature(temperature_c)
@@ -316,7 +322,7 @@ def _heat_rates(
         temperature_c,
         entropic_coefficient_v_per_k,
     )
-    generation_w = irreversible_w + reversible_w
+    generation_w = irreversible_w + reversible_w + external_heat_w
     convective_rejection_w = heat_transfer_w_per_k * (
         temperature_c - ambient_temperature_c
     )
@@ -329,6 +335,7 @@ def _heat_rates(
         resistance_ohm=resistance_ohm,
         irreversible_w=irreversible_w,
         reversible_w=reversible_w,
+        external_w=external_heat_w,
         generation_w=generation_w,
         convective_rejection_w=convective_rejection_w,
         radiative_rejection_w=radiative_rejection_w,
@@ -344,6 +351,7 @@ def _rk4_temperature_change_c(
     ambient_temperature_c: float,
     radiative_surroundings_temperature_c: float,
     entropic_coefficient_v_per_k: float,
+    external_heat_w: float,
     heat_transfer_w_per_k: float,
     interval_duration_s: float,
 ) -> float:
@@ -361,6 +369,7 @@ def _rk4_temperature_change_c(
             ambient_temperature_c,
             radiative_surroundings_temperature_c,
             entropic_coefficient_v_per_k,
+            external_heat_w,
             heat_transfer_w_per_k,
         )
         return rates.net_w / spec.thermal_capacity_j_per_k
@@ -389,6 +398,7 @@ def load_current_profile(path: Path) -> CurrentProfile:
             "ambient_temperature_c",
             "radiative_surroundings_temperature_c",
             "entropic_coefficient_v_per_k",
+            "external_heat_w",
             "heat_transfer_w_per_k",
         ]
         fieldnames = reader.fieldnames or []
@@ -403,7 +413,8 @@ def load_current_profile(path: Path) -> CurrentProfile:
                 "profile CSV header must be exactly time_s,current_a followed by "
                 "any of duration_s,ambient_temperature_c,"
                 "radiative_surroundings_temperature_c,"
-                "entropic_coefficient_v_per_k,heat_transfer_w_per_k in that order"
+                "entropic_coefficient_v_per_k,external_heat_w,"
+                "heat_transfer_w_per_k in that order"
             )
         has_ambient = "ambient_temperature_c" in fieldnames
         has_radiative_surroundings = (
@@ -411,6 +422,7 @@ def load_current_profile(path: Path) -> CurrentProfile:
         )
         has_duration = "duration_s" in fieldnames
         has_entropic_coefficient = "entropic_coefficient_v_per_k" in fieldnames
+        has_external_heat = "external_heat_w" in fieldnames
         has_heat_transfer = "heat_transfer_w_per_k" in fieldnames
         rows = list(reader)
 
@@ -425,6 +437,7 @@ def load_current_profile(path: Path) -> CurrentProfile:
     ambient_temperatures: list[float] = []
     radiative_surroundings_temperatures: list[float] = []
     entropic_coefficients: list[float] = []
+    external_heats: list[float] = []
     heat_transfers: list[float] = []
     for line_number, row in enumerate(rows, start=2):
         try:
@@ -444,6 +457,9 @@ def load_current_profile(path: Path) -> CurrentProfile:
                 if has_entropic_coefficient
                 else None
             )
+            external_heat_w = (
+                float(row["external_heat_w"]) if has_external_heat else None
+            )
             heat_transfer_w_per_k = (
                 float(row["heat_transfer_w_per_k"]) if has_heat_transfer else None
             )
@@ -460,6 +476,8 @@ def load_current_profile(path: Path) -> CurrentProfile:
             values.append(radiative_surroundings_temperature_c)
         if entropic_coefficient_v_per_k is not None:
             values.append(entropic_coefficient_v_per_k)
+        if external_heat_w is not None:
+            values.append(external_heat_w)
         if heat_transfer_w_per_k is not None:
             values.append(heat_transfer_w_per_k)
         if None in row or any(not math.isfinite(value) for value in values):
@@ -494,6 +512,8 @@ def load_current_profile(path: Path) -> CurrentProfile:
             )
         if entropic_coefficient_v_per_k is not None:
             entropic_coefficients.append(entropic_coefficient_v_per_k)
+        if external_heat_w is not None:
+            external_heats.append(external_heat_w)
         if heat_transfer_w_per_k is not None:
             heat_transfers.append(heat_transfer_w_per_k)
 
@@ -547,6 +567,7 @@ def load_current_profile(path: Path) -> CurrentProfile:
         entropic_coefficient_v_per_k=(
             tuple(entropic_coefficients) if has_entropic_coefficient else None
         ),
+        external_heat_w=(tuple(external_heats) if has_external_heat else None),
         heat_transfer_w_per_k=(tuple(heat_transfers) if has_heat_transfer else None),
         interval_duration_s=tuple(durations),
     )
@@ -559,6 +580,7 @@ def simulate_lumped_temperature(
     radiative_surroundings_temperatures_c: Sequence[float] | None = None,
     interval_durations_s: Sequence[float] | None = None,
     entropic_coefficients_v_per_k: Sequence[float] | None = None,
+    external_heats_w: Sequence[float] | None = None,
     heat_transfers_w_per_k: Sequence[float] | None = None,
 ) -> ThermalSimulation:
     """Integrate a one-node thermal balance over piecewise-constant intervals."""
@@ -640,6 +662,17 @@ def simulate_lumped_temperature(
         if any(not math.isfinite(value) for value in entropic_coefficients):
             raise ValueError("all entropic coefficient values must be finite")
 
+    if external_heats_w is None:
+        external_heats = (spec.external_heat_w,) * len(currents)
+    else:
+        external_heats = tuple(float(value) for value in external_heats_w)
+        if len(external_heats) != len(currents):
+            raise ValueError(
+                "external_heats_w must contain one value per current interval"
+            )
+        if any(not math.isfinite(value) for value in external_heats):
+            raise ValueError("all external heat values must be finite")
+
     if heat_transfers_w_per_k is None:
         heat_transfers = (spec.heat_transfer_w_per_k,) * len(currents)
     else:
@@ -670,6 +703,7 @@ def simulate_lumped_temperature(
         radiative_surroundings_temperature_c,
         interval_duration_s,
         entropic_coefficient_v_per_k,
+        external_heat_w,
         heat_transfer_w_per_k,
     ) in zip(
         currents,
@@ -677,6 +711,7 @@ def simulate_lumped_temperature(
         radiative_surroundings_temperatures,
         interval_durations,
         entropic_coefficients,
+        external_heats,
         heat_transfers,
         strict=True,
     ):
@@ -688,6 +723,7 @@ def simulate_lumped_temperature(
             ambient_temperature_c,
             radiative_surroundings_temperature_c,
             entropic_coefficient_v_per_k,
+            external_heat_w,
             heat_transfer_w_per_k,
         )
         if integration_method is IntegrationMethod.EXPLICIT_EULER:
@@ -729,6 +765,7 @@ def simulate_lumped_temperature(
                 ambient_temperature_c,
                 radiative_surroundings_temperature_c,
                 entropic_coefficient_v_per_k,
+                external_heat_w,
                 heat_transfer_w_per_k,
                 interval_duration_s,
             )
@@ -764,6 +801,7 @@ def simulate_lumped_temperature(
         heat_transfer_w_per_k=heat_transfers,
         resistance_ohm=tuple(interval_resistance),
         entropic_coefficient_v_per_k=tuple(interval_entropic_coefficient),
+        external_heat_w=external_heats,
         irreversible_heat_w=tuple(irreversible_heat),
         reversible_heat_w=tuple(reversible_heat),
         heat_generation_w=tuple(generated_heat),
@@ -796,6 +834,7 @@ def write_simulation_csv(path: Path, result: ThermalSimulation) -> None:
         "radiating_area_m2",
         "resistance_ohm",
         "entropic_coefficient_v_per_k",
+        "external_heat_w",
         "start_temperature_c",
         "end_temperature_c",
         "irreversible_heat_w",
@@ -828,6 +867,7 @@ def write_simulation_csv(path: Path, result: ThermalSimulation) -> None:
                 "entropic_coefficient_v_per_k": (
                     result.entropic_coefficient_v_per_k[index]
                 ),
+                "external_heat_w": result.external_heat_w[index],
                 "start_temperature_c": result.temperature_c[index],
                 "end_temperature_c": result.temperature_c[index + 1],
                 "irreversible_heat_w": result.irreversible_heat_w[index],
@@ -868,6 +908,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         default=25.0,
     )
     parser.add_argument("--entropic-coefficient-v-per-k", type=float)
+    parser.add_argument("--external-heat-w", type=float)
     parser.add_argument("--heat-transfer-w-per-k", type=float)
     parser.add_argument("--emissivity", type=float, default=0.0)
     parser.add_argument("--radiating-area-m2", type=float, default=0.0)
@@ -891,6 +932,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     radiative_surroundings_temperatures_c = None
     interval_durations_s = None
     entropic_coefficients_v_per_k = None
+    external_heats_w = None
     heat_transfers_w_per_k = None
     if args.profile_csv:
         conflicting = [
@@ -935,6 +977,11 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "--heat-transfer-w-per-k cannot be combined with a profile "
                 "that contains heat_transfer_w_per_k"
             )
+        if profile.external_heat_w is not None and args.external_heat_w is not None:
+            raise ValueError(
+                "--external-heat-w cannot be combined with a profile that "
+                "contains external_heat_w"
+            )
         currents = profile.current_a
         ambient_temperatures_c = profile.ambient_temperature_c
         radiative_surroundings_temperatures_c = (
@@ -942,6 +989,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         interval_durations_s = profile.interval_duration_s
         entropic_coefficients_v_per_k = profile.entropic_coefficient_v_per_k
+        external_heats_w = profile.external_heat_w
         heat_transfers_w_per_k = profile.heat_transfer_w_per_k
         time_step_s = profile.time_step_s or profile.interval_duration_s[0]
     else:
@@ -979,6 +1027,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             if args.entropic_coefficient_v_per_k is None
             else args.entropic_coefficient_v_per_k
         ),
+        external_heat_w=(0.0 if args.external_heat_w is None else args.external_heat_w),
         heat_transfer_w_per_k=(
             1.2 if args.heat_transfer_w_per_k is None else args.heat_transfer_w_per_k
         ),
@@ -1002,6 +1051,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         ),
         interval_durations_s=interval_durations_s,
         entropic_coefficients_v_per_k=entropic_coefficients_v_per_k,
+        external_heats_w=external_heats_w,
         heat_transfers_w_per_k=heat_transfers_w_per_k,
     )
 
@@ -1038,6 +1088,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         "Reversible heat range: "
         f"{min(result.reversible_heat_w):.6f} to "
         f"{max(result.reversible_heat_w):.6f} W"
+    )
+    print(
+        "External heat range: "
+        f"{min(result.external_heat_w):.6f} to "
+        f"{max(result.external_heat_w):.6f} W"
     )
     print(
         "Total heat-source range: "

--- a/tests/test_lumped_cell_thermal.py
+++ b/tests/test_lumped_cell_thermal.py
@@ -153,6 +153,61 @@ class LumpedCellThermalTests(unittest.TestCase):
         self.assertEqual(result.reversible_heat_w, (0.0, 0.0))
         self.assertEqual(result.irreversible_heat_w, result.heat_generation_w)
 
+    def test_constant_external_heat_matches_adiabatic_energy_rise(self):
+        result = simulate_lumped_temperature(
+            [0.0, 0.0],
+            LumpedThermalSpec(
+                mass_kg=1.0,
+                specific_heat_j_per_kg_k=1000.0,
+                resistance_ohm=0.0,
+                external_heat_w=10.0,
+                heat_transfer_w_per_k=0.0,
+                time_step_s=50.0,
+            ),
+        )
+
+        self.assertEqual(result.external_heat_w, (10.0, 10.0))
+        self.assertEqual(result.heat_generation_w, (10.0, 10.0))
+        self.assertEqual(result.temperature_c, (25.0, 25.5, 26.0))
+        self.assertAlmostEqual(result.stored_energy_change_j, 1000.0)
+        self.assertAlmostEqual(result.energy_balance_error_j, 0.0)
+
+    def test_exact_linear_external_heat_matches_closed_form_cooling(self):
+        result = simulate_lumped_temperature(
+            [0.0],
+            LumpedThermalSpec(
+                mass_kg=1.0,
+                specific_heat_j_per_kg_k=1000.0,
+                resistance_ohm=0.0,
+                external_heat_w=100.0,
+                heat_transfer_w_per_k=10.0,
+                time_step_s=100.0,
+                integration_method=IntegrationMethod.EXACT_LINEAR,
+            ),
+        )
+
+        expected_temperature_c = 25.0 + 10.0 * (1.0 - math.exp(-1.0))
+        self.assertAlmostEqual(result.temperature_c[-1], expected_temperature_c)
+        self.assertAlmostEqual(result.energy_balance_error_j, 0.0)
+
+    def test_interval_external_heat_profile_overrides_constant_spec_value(self):
+        result = simulate_lumped_temperature(
+            [0.0, 0.0],
+            LumpedThermalSpec(
+                mass_kg=1.0,
+                specific_heat_j_per_kg_k=1000.0,
+                resistance_ohm=0.0,
+                external_heat_w=1.0,
+                heat_transfer_w_per_k=0.0,
+                time_step_s=100.0,
+            ),
+            external_heats_w=[10.0, -5.0],
+        )
+
+        self.assertEqual(result.external_heat_w, (10.0, -5.0))
+        self.assertEqual(result.temperature_c, (25.0, 26.0, 25.5))
+        self.assertAlmostEqual(result.energy_balance_error_j, 0.0)
+
     def test_reversible_heat_changes_sign_with_current_direction(self):
         spec = LumpedThermalSpec(
             entropic_coefficient_v_per_k=0.0001,
@@ -373,6 +428,7 @@ class LumpedCellThermalTests(unittest.TestCase):
         self.assertIsNone(profile.ambient_temperature_c)
         self.assertIsNone(profile.radiative_surroundings_temperature_c)
         self.assertIsNone(profile.entropic_coefficient_v_per_k)
+        self.assertIsNone(profile.external_heat_w)
         self.assertEqual(profile.time_step_s, 60.0)
         self.assertEqual(profile.interval_duration_s, (60.0, 60.0, 60.0))
 
@@ -455,6 +511,31 @@ class LumpedCellThermalTests(unittest.TestCase):
         self.assertEqual(profile.interval_duration_s, (300.0, 300.0))
         self.assertEqual(profile.ambient_temperature_c, (35.0, 35.0))
         self.assertEqual(profile.heat_transfer_w_per_k, (0.6, 4.0))
+
+    def test_loads_profile_with_signed_external_heat(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "profile.csv"
+            path.write_text(
+                "time_s,current_a,duration_s,external_heat_w\n"
+                "0,0,100,10\n"
+                "100,0,100,-5\n",
+                encoding="utf-8",
+            )
+            profile = load_current_profile(path)
+        self.assertEqual(profile.interval_duration_s, (100.0, 100.0))
+        self.assertEqual(profile.external_heat_w, (10.0, -5.0))
+
+    def test_rejects_invalid_external_heat_profile(self):
+        with self.assertRaisesRegex(ValueError, "one value per current interval"):
+            simulate_lumped_temperature(
+                [0.0, 0.0],
+                external_heats_w=[1.0],
+            )
+        with self.assertRaisesRegex(ValueError, "external heat values must be finite"):
+            simulate_lumped_temperature(
+                [0.0],
+                external_heats_w=[math.nan],
+            )
 
     def test_interval_ambient_changes_heat_rejection_and_temperature(self):
         constant = simulate_lumped_temperature([0.0, 0.0])
@@ -656,6 +737,7 @@ class LumpedCellThermalTests(unittest.TestCase):
         self.assertEqual(float(rows[0]["heat_transfer_w_per_k"]), 1.2)
         self.assertEqual(float(rows[0]["resistance_ohm"]), 0.004)
         self.assertEqual(float(rows[0]["entropic_coefficient_v_per_k"]), 0.0)
+        self.assertEqual(float(rows[0]["external_heat_w"]), 0.0)
         self.assertEqual(float(rows[0]["reversible_heat_w"]), 0.0)
         self.assertEqual(
             float(rows[0]["irreversible_heat_w"]),
@@ -788,6 +870,70 @@ class LumpedCellThermalTests(unittest.TestCase):
         output = standard_output.getvalue()
         self.assertIn("Entropic coefficient range: 0.0001 to 0.0001 V/K", output)
         self.assertIn("Reversible heat range: -2.981500 to -2.981500 W", output)
+
+    def test_cli_applies_constant_external_heat(self):
+        standard_output = io.StringIO()
+        with contextlib.redirect_stdout(standard_output):
+            exit_code = main(
+                [
+                    "--current-a",
+                    "0",
+                    "--duration-s",
+                    "100",
+                    "--time-step-s",
+                    "100",
+                    "--external-heat-w",
+                    "10",
+                    "--heat-transfer-w-per-k",
+                    "0",
+                ]
+            )
+        self.assertEqual(exit_code, 0)
+        output = standard_output.getvalue()
+        self.assertIn("External heat range: 10.000000 to 10.000000 W", output)
+        self.assertIn("Final temperature: 25.952 degC", output)
+
+    def test_cli_runs_external_heat_profile_and_exports_source(self):
+        with tempfile.TemporaryDirectory() as directory:
+            profile_path = Path(directory) / "profile.csv"
+            output_path = Path(directory) / "result.csv"
+            profile_path.write_text(
+                "time_s,current_a,duration_s,external_heat_w\n"
+                "0,0,100,10\n"
+                "100,0,100,-5\n",
+                encoding="utf-8",
+            )
+            standard_output = io.StringIO()
+            with contextlib.redirect_stdout(standard_output):
+                exit_code = main(
+                    [
+                        "--profile-csv",
+                        str(profile_path),
+                        "--output-csv",
+                        str(output_path),
+                        "--heat-transfer-w-per-k",
+                        "0",
+                    ]
+                )
+            with output_path.open("r", encoding="utf-8", newline="") as output_file:
+                rows = list(csv.DictReader(output_file))
+        self.assertEqual(exit_code, 0)
+        self.assertIn(
+            "External heat range: -5.000000 to 10.000000 W",
+            standard_output.getvalue(),
+        )
+        self.assertEqual(
+            [float(row["external_heat_w"]) for row in rows],
+            [10.0, -5.0],
+        )
+        for row in rows:
+            self.assertAlmostEqual(
+                float(row["heat_generation_w"]),
+                float(row["irreversible_heat_w"])
+                + float(row["reversible_heat_w"])
+                + float(row["external_heat_w"]),
+                places=9,
+            )
 
     def test_cli_runs_entropic_profile_and_exports_heat_components(self):
         with tempfile.TemporaryDirectory() as directory:
@@ -973,6 +1119,24 @@ class LumpedCellThermalTests(unittest.TestCase):
                         str(profile_path),
                         "--entropic-coefficient-v-per-k",
                         "0.0002",
+                    ]
+                )
+
+    def test_profile_external_heat_rejects_constant_override(self):
+        with tempfile.TemporaryDirectory() as directory:
+            profile_path = Path(directory) / "profile.csv"
+            profile_path.write_text(
+                "time_s,current_a,external_heat_w\n"
+                "0,0,10\n1,10,-5\n",
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(ValueError, "cannot be combined"):
+                main(
+                    [
+                        "--profile-csv",
+                        str(profile_path),
+                        "--external-heat-w",
+                        "2",
                     ]
                 )
 


### PR DESCRIPTION
## Summary
- add a signed constant or interval-profile external heat source to the lumped thermal balance
- preserve the source separately in result and CSV records while including it in total generation and net energy
- support explicit Euler, exact-linear, and RK4 paths with strict profile validation
- add a committed reference profile, CI execution, tests, and documented limitations

## Why
The model previously required heater, neighboring-component, interconnect, or calibrated parasitic heat to be hidden inside electrical or boundary parameters. A separate source keeps those assumptions explicit and auditable.

## Validation
- `git diff --check`
- `python -m unittest discover -s tests -v` (67 tests)
- `python -m compileall -q models tests`
- committed external heat profile executed with exact-linear integration