### PR TITLE
Add temperature limit exposure assessment

### DIFF
--- a/.github/workflows/markdown-maintenance.yml
+++ b/.github/workflows/markdown-maintenance.yml
@@ -66,6 +66,15 @@ jobs:
           --rk4-max-step-s 0.5
           --output-csv "$RUNNER_TEMP/radiative-surroundings-intervals.csv"
 
+      - name: Assess temperature-limit exposure
+        run: >-
+          python models/lumped_cell_thermal.py
+          --current-a 75
+          --duration-s 600
+          --temperature-limit-c 30
+          --temperature-limit-c 35
+          --limit-report-csv "$RUNNER_TEMP/temperature-limits.csv"
+
       - name: Check Markdown links
         uses: lycheeverse/lychee-action@v2
         with:

--- a/README.md
+++ b/README.md
@@ -131,6 +131,10 @@ python models/lumped_cell_thermal.py `
   --emissivity 0.85 --radiating-area-m2 0.03 `
   --integration-method rk4 --rk4-max-step-s 0.5 `
   --output-csv results/radiative_cooling_intervals.csv
+python models/lumped_cell_thermal.py `
+  --current-a 75 --duration-s 600 `
+  --temperature-limit-c 30 --temperature-limit-c 35 `
+  --limit-report-csv results/temperature-limits.csv
 python -m unittest discover -s tests -v
 ```
 
@@ -140,7 +144,8 @@ supports traceable charge/discharge duty cycles, optional interval ambient
 and radiative-surroundings temperatures, entropic coefficients, and
 external heat sources and heat-transfer coefficients, explicit nonuniform
 interval durations, optional diffuse-gray radiation, and interval-level CSV
-results.
+results. Repeatable temperature limits add first-crossing, exposure-duration,
+and peak-margin summaries without changing the thermal integration.
 
 ## Contribution Entry Points
 

--- a/models/README.md
+++ b/models/README.md
@@ -324,6 +324,31 @@ documented before engineering use. A negative source can remove more heat than
 the electrical terms generate, but it does not enforce coolant, surface, or
 absolute-temperature constraints beyond the model's existing validation.
 
+## Temperature-Limit Exposure
+
+Assess one or more project-defined temperature limits after a simulation and
+write one summary row per limit:
+
+```powershell
+python models/lumped_cell_thermal.py `
+  --current-a 75 --duration-s 600 `
+  --temperature-limit-c 30 `
+  --temperature-limit-c 35 `
+  --limit-report-csv results/temperature-limits.csv
+```
+
+Each assessment reports whether the limit was exceeded, the first crossing
+time, total time above the limit, exposure fraction, peak temperature, and
+signed margin from the peak to the limit. A negative margin means the simulated
+peak exceeded the limit. The limit itself is not counted as an exceedance.
+
+Crossing times and exposure duration use piecewise-linear interpolation between
+the reported temperature states. This makes the calculation deterministic for
+uniform and variable-duration profiles, but it does not reconstruct motion
+inside an integration interval. Use a reviewed time-step sensitivity study when
+a short excursion or precise threshold timing matters. Temperature limits are
+project inputs, not safety recommendations from this educational model.
+
 ## Explicit Limitations
 
 - Resistance may use an optional linear temperature coefficient, but it does
@@ -345,6 +370,8 @@ absolute-temperature constraints beyond the model's existing validation.
   constant current, ambient temperature, coefficients, and heat transfer over
   each interval. Explicit durations may vary, but the model does not interpolate
   within an interval.
+- Temperature-limit exposure is linearly interpolated between reported states;
+  an unreported within-step excursion can be missed.
 - Exact integration applies only to the model's linear within-interval
   equation. Surface radiation uses bounded-step RK4; nonlinear resistance
   maps would require a separately validated extension.

--- a/models/lumped_cell_thermal.py
+++ b/models/lumped_cell_thermal.py
@@ -185,6 +185,19 @@ class LumpedThermalSpec:
 
 
 @dataclass(frozen=True)
+class TemperatureLimitAssessment:
+    """Piecewise-linear exposure metrics for one temperature limit."""
+
+    limit_temperature_c: float
+    exceeded: bool
+    first_exceedance_time_s: float | None
+    time_above_limit_s: float
+    exposure_fraction: float
+    peak_temperature_c: float
+    margin_to_limit_c: float
+
+
+@dataclass(frozen=True)
 class ThermalSimulation:
     """Discrete temperatures and interval-level heat flows."""
 
@@ -232,6 +245,58 @@ class ThermalSimulation:
     @property
     def duration_s(self) -> float:
         return sum(self.interval_duration_s)
+
+    def assess_temperature_limit(
+        self,
+        limit_temperature_c: float,
+    ) -> TemperatureLimitAssessment:
+        """Assess time above a limit by interpolating between result states."""
+
+        _temperature_k(limit_temperature_c, "limit_temperature_c")
+        first_exceedance_time_s: float | None = None
+        time_above_limit_s = 0.0
+        if self.temperature_c[0] > limit_temperature_c:
+            first_exceedance_time_s = self.time_s[0]
+
+        for start_time_s, end_time_s, start_c, end_c in zip(
+            self.time_s[:-1],
+            self.time_s[1:],
+            self.temperature_c[:-1],
+            self.temperature_c[1:],
+            strict=True,
+        ):
+            duration_s = end_time_s - start_time_s
+            start_above = start_c > limit_temperature_c
+            end_above = end_c > limit_temperature_c
+            if start_above and end_above:
+                time_above_limit_s += duration_s
+                if first_exceedance_time_s is None:
+                    first_exceedance_time_s = start_time_s
+                continue
+            if not start_above and not end_above:
+                continue
+
+            crossing_fraction = (limit_temperature_c - start_c) / (end_c - start_c)
+            crossing_time_s = start_time_s + crossing_fraction * duration_s
+            if end_above:
+                time_above_limit_s += end_time_s - crossing_time_s
+                if first_exceedance_time_s is None:
+                    first_exceedance_time_s = crossing_time_s
+            else:
+                time_above_limit_s += crossing_time_s - start_time_s
+                if first_exceedance_time_s is None:
+                    first_exceedance_time_s = start_time_s
+
+        peak_temperature_c = self.peak_temperature_c
+        return TemperatureLimitAssessment(
+            limit_temperature_c=limit_temperature_c,
+            exceeded=first_exceedance_time_s is not None,
+            first_exceedance_time_s=first_exceedance_time_s,
+            time_above_limit_s=time_above_limit_s,
+            exposure_fraction=time_above_limit_s / self.duration_s,
+            peak_temperature_c=peak_temperature_c,
+            margin_to_limit_c=limit_temperature_c - peak_temperature_c,
+        )
 
     @property
     def time_step_s(self) -> float | None:
@@ -887,12 +952,68 @@ def write_simulation_csv(path: Path, result: ThermalSimulation) -> None:
             )
 
 
+def write_temperature_limit_csv(
+    path: Path,
+    assessments: Sequence[TemperatureLimitAssessment],
+) -> None:
+    """Write one auditable summary row per assessed temperature limit."""
+
+    if not assessments:
+        raise ValueError("assessments must contain at least one temperature limit")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fieldnames = [
+        "limit_temperature_c",
+        "exceeded",
+        "first_exceedance_time_s",
+        "time_above_limit_s",
+        "exposure_fraction",
+        "peak_temperature_c",
+        "margin_to_limit_c",
+    ]
+    with path.open("w", encoding="utf-8", newline="") as output_file:
+        writer = csv.DictWriter(output_file, fieldnames=fieldnames)
+        writer.writeheader()
+        for assessment in assessments:
+            writer.writerow(
+                {
+                    "limit_temperature_c": format(
+                        assessment.limit_temperature_c, ".12g"
+                    ),
+                    "exceeded": str(assessment.exceeded).lower(),
+                    "first_exceedance_time_s": (
+                        ""
+                        if assessment.first_exceedance_time_s is None
+                        else format(assessment.first_exceedance_time_s, ".12g")
+                    ),
+                    "time_above_limit_s": format(
+                        assessment.time_above_limit_s, ".12g"
+                    ),
+                    "exposure_fraction": format(
+                        assessment.exposure_fraction, ".12g"
+                    ),
+                    "peak_temperature_c": format(
+                        assessment.peak_temperature_c, ".12g"
+                    ),
+                    "margin_to_limit_c": format(
+                        assessment.margin_to_limit_c, ".12g"
+                    ),
+                }
+            )
+
+
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Run a constant-current or CSV-profile cell thermal calculation."
     )
     parser.add_argument("--profile-csv", type=Path)
     parser.add_argument("--output-csv", type=Path)
+    parser.add_argument(
+        "--temperature-limit-c",
+        action="append",
+        type=float,
+        dest="temperature_limits_c",
+    )
+    parser.add_argument("--limit-report-csv", type=Path)
     parser.add_argument("--current-a", type=float)
     parser.add_argument("--duration-s", type=float)
     parser.add_argument("--time-step-s", type=float)
@@ -928,6 +1049,16 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = parse_args(argv)
+    temperature_limits_c = tuple(args.temperature_limits_c or ())
+    if args.limit_report_csv and not temperature_limits_c:
+        raise ValueError(
+            "--limit-report-csv requires at least one --temperature-limit-c"
+        )
+    if len(set(temperature_limits_c)) != len(temperature_limits_c):
+        raise ValueError("--temperature-limit-c values must be unique")
+    for limit_temperature_c in temperature_limits_c:
+        _temperature_k(limit_temperature_c, "temperature limit")
+
     ambient_temperatures_c = None
     radiative_surroundings_temperatures_c = None
     interval_durations_s = None
@@ -1057,6 +1188,12 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if args.output_csv:
         write_simulation_csv(args.output_csv, result)
+    limit_assessments = tuple(
+        result.assess_temperature_limit(limit_temperature_c)
+        for limit_temperature_c in temperature_limits_c
+    )
+    if args.limit_report_csv:
+        write_temperature_limit_csv(args.limit_report_csv, limit_assessments)
 
     print(f"Intervals: {len(currents)}")
     print(f"Duration: {result.duration_s:.3f} s")
@@ -1114,8 +1251,28 @@ def main(argv: Sequence[str] | None = None) -> int:
     print(f"Stored thermal energy: {result.stored_energy_change_j:.3f} J")
     print(f"Integrated net heat: {result.integrated_net_heat_j:.3f} J")
     print(f"Energy-balance error: {result.energy_balance_error_j:.6e} J")
+    for assessment in limit_assessments:
+        status = "EXCEEDED" if assessment.exceeded else "PASS"
+        first_exceedance = (
+            "not exceeded"
+            if assessment.first_exceedance_time_s is None
+            else f"{assessment.first_exceedance_time_s:.6g} s"
+        )
+        print(
+            f"Temperature limit {assessment.limit_temperature_c:.6g} degC: "
+            f"{status}"
+        )
+        print(f"  First exceedance: {first_exceedance}")
+        print(
+            "  Exposure: "
+            f"{assessment.time_above_limit_s:.6g} s "
+            f"({assessment.exposure_fraction:.6%})"
+        )
+        print(f"  Margin to limit: {assessment.margin_to_limit_c:.6g} degC")
     if args.output_csv:
         print(f"Interval results: {args.output_csv}")
+    if args.limit_report_csv:
+        print(f"Temperature-limit report: {args.limit_report_csv}")
     return 0
 
 

--- a/tests/test_lumped_cell_thermal.py
+++ b/tests/test_lumped_cell_thermal.py
@@ -12,14 +12,198 @@ from models.lumped_cell_thermal import (
     IntegrationMethod,
     LumpedThermalSpec,
     STEFAN_BOLTZMANN_W_PER_M2_K4,
+    TemperatureLimitAssessment,
     load_current_profile,
     main,
     simulate_lumped_temperature,
     write_simulation_csv,
+    write_temperature_limit_csv,
 )
 
 
 class LumpedCellThermalTests(unittest.TestCase):
+    @staticmethod
+    def linear_heating_result():
+        return simulate_lumped_temperature(
+            [0.0, 0.0],
+            LumpedThermalSpec(
+                mass_kg=1.0,
+                specific_heat_j_per_kg_k=1.0,
+                resistance_ohm=0.0,
+                external_heat_w=1.0,
+                heat_transfer_w_per_k=0.0,
+                initial_temperature_c=20.0,
+                time_step_s=10.0,
+            ),
+        )
+
+    def test_temperature_limit_interpolates_crossing_and_exposure(self):
+        assessment = self.linear_heating_result().assess_temperature_limit(25.0)
+
+        self.assertEqual(
+            assessment,
+            TemperatureLimitAssessment(
+                limit_temperature_c=25.0,
+                exceeded=True,
+                first_exceedance_time_s=5.0,
+                time_above_limit_s=15.0,
+                exposure_fraction=0.75,
+                peak_temperature_c=40.0,
+                margin_to_limit_c=-15.0,
+            ),
+        )
+
+    def test_temperature_limit_counts_heating_and_cooling_crossings(self):
+        result = simulate_lumped_temperature(
+            [0.0, 0.0],
+            LumpedThermalSpec(
+                mass_kg=1.0,
+                specific_heat_j_per_kg_k=1.0,
+                resistance_ohm=0.0,
+                heat_transfer_w_per_k=0.0,
+                initial_temperature_c=20.0,
+                time_step_s=10.0,
+            ),
+            external_heats_w=(1.0, -1.0),
+        )
+
+        assessment = result.assess_temperature_limit(25.0)
+
+        self.assertEqual(assessment.first_exceedance_time_s, 5.0)
+        self.assertEqual(assessment.time_above_limit_s, 10.0)
+        self.assertEqual(assessment.exposure_fraction, 0.5)
+
+    def test_temperature_limit_uses_variable_interval_durations(self):
+        result = simulate_lumped_temperature(
+            [0.0, 0.0],
+            LumpedThermalSpec(
+                mass_kg=1.0,
+                specific_heat_j_per_kg_k=1.0,
+                resistance_ohm=0.0,
+                heat_transfer_w_per_k=0.0,
+                initial_temperature_c=20.0,
+            ),
+            interval_durations_s=(5.0, 15.0),
+            external_heats_w=(2.0, -2.0 / 3.0),
+        )
+
+        assessment = result.assess_temperature_limit(25.0)
+
+        self.assertEqual(result.time_s, (0.0, 5.0, 20.0))
+        self.assertEqual(assessment.first_exceedance_time_s, 2.5)
+        self.assertEqual(assessment.time_above_limit_s, 10.0)
+
+    def test_temperature_limit_equal_to_peak_is_not_exceeded(self):
+        assessment = self.linear_heating_result().assess_temperature_limit(40.0)
+
+        self.assertFalse(assessment.exceeded)
+        self.assertIsNone(assessment.first_exceedance_time_s)
+        self.assertEqual(assessment.time_above_limit_s, 0.0)
+        self.assertEqual(assessment.margin_to_limit_c, 0.0)
+
+    def test_temperature_limit_detects_initial_exceedance(self):
+        result = simulate_lumped_temperature(
+            [0.0],
+            LumpedThermalSpec(
+                mass_kg=1.0,
+                specific_heat_j_per_kg_k=1.0,
+                resistance_ohm=0.0,
+                external_heat_w=-1.0,
+                heat_transfer_w_per_k=0.0,
+                initial_temperature_c=30.0,
+                time_step_s=10.0,
+            ),
+        )
+
+        assessment = result.assess_temperature_limit(25.0)
+
+        self.assertTrue(assessment.exceeded)
+        self.assertEqual(assessment.first_exceedance_time_s, 0.0)
+        self.assertEqual(assessment.time_above_limit_s, 5.0)
+
+    def test_temperature_limit_rejects_nonphysical_values(self):
+        result = self.linear_heating_result()
+        for value in (float("nan"), float("inf"), -273.15):
+            with self.subTest(value=value):
+                with self.assertRaises(ValueError):
+                    result.assess_temperature_limit(value)
+
+    def test_writes_temperature_limit_report(self):
+        result = self.linear_heating_result()
+        assessments = (
+            result.assess_temperature_limit(25.0),
+            result.assess_temperature_limit(45.0),
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "limits.csv"
+            write_temperature_limit_csv(path, assessments)
+            with path.open("r", encoding="utf-8", newline="") as output_file:
+                rows = list(csv.DictReader(output_file))
+
+        self.assertEqual([row["exceeded"] for row in rows], ["true", "false"])
+        self.assertEqual(float(rows[0]["first_exceedance_time_s"]), 5.0)
+        self.assertEqual(rows[1]["first_exceedance_time_s"], "")
+        self.assertEqual(float(rows[1]["margin_to_limit_c"]), 5.0)
+
+    def test_temperature_limit_report_requires_assessments(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "limits.csv"
+            with self.assertRaisesRegex(ValueError, "at least one"):
+                write_temperature_limit_csv(path, ())
+
+    def test_cli_reports_repeated_temperature_limits(self):
+        standard_output = io.StringIO()
+        with tempfile.TemporaryDirectory() as directory:
+            report_path = Path(directory) / "limits.csv"
+            with contextlib.redirect_stdout(standard_output):
+                exit_code = main(
+                    [
+                        "--current-a",
+                        "0",
+                        "--duration-s",
+                        "20",
+                        "--time-step-s",
+                        "10",
+                        "--mass-kg",
+                        "1",
+                        "--specific-heat-j-per-kg-k",
+                        "1",
+                        "--heat-transfer-w-per-k",
+                        "0",
+                        "--external-heat-w",
+                        "1",
+                        "--initial-temperature-c",
+                        "20",
+                        "--temperature-limit-c",
+                        "25",
+                        "--temperature-limit-c",
+                        "45",
+                        "--limit-report-csv",
+                        str(report_path),
+                    ]
+                )
+            rows = list(csv.DictReader(report_path.read_text().splitlines()))
+
+        output = standard_output.getvalue()
+        self.assertEqual(exit_code, 0)
+        self.assertIn("Temperature limit 25 degC: EXCEEDED", output)
+        self.assertIn("First exceedance: 5 s", output)
+        self.assertIn("Temperature limit 45 degC: PASS", output)
+        self.assertEqual(len(rows), 2)
+
+    def test_cli_rejects_missing_or_duplicate_temperature_limits(self):
+        with self.assertRaisesRegex(ValueError, "requires at least one"):
+            main(["--limit-report-csv", "limits.csv"])
+        with self.assertRaisesRegex(ValueError, "must be unique"):
+            main(
+                [
+                    "--temperature-limit-c",
+                    "45",
+                    "--temperature-limit-c",
+                    "45",
+                ]
+            )
+
     def test_zero_current_stays_at_ambient_equilibrium(self):
         result = simulate_lumped_temperature([0.0] * 120)
         self.assertTrue(all(value == 25.0 for value in result.temperature_c))


### PR DESCRIPTION
## Summary
- add typed temperature-limit assessments for first crossing, time above limit, exposure fraction, and peak margin
- support repeated CLI limits and an auditable one-row-per-limit CSV report
- document piecewise-linear interpolation limits and exercise the report in hosted CI

## Verification
- 77 unit tests
- all workflow-equivalent model commands
- Python compilation and diff checks