### PR TITLE
Add final thermal-limit recovery time

### DIFF
--- a/models/README.md
+++ b/models/README.md
@@ -337,8 +337,9 @@ python models/lumped_cell_thermal.py `
   --limit-report-csv results/temperature-limits.csv
 ```
 
-Each assessment reports whether the limit was exceeded, the first crossing
-time, total time above the limit, exposure fraction, peak temperature, and
+Each assessment reports whether the limit was exceeded, the first-crossing
+time, final recovery time when the trace ends at or below the limit, total
+time above the limit, exposure fraction, peak temperature, and
 signed margin from the peak to the limit. A negative margin means the simulated
 peak exceeded the limit. The limit itself is not counted as an exceedance.
 

--- a/models/lumped_cell_thermal.py
+++ b/models/lumped_cell_thermal.py
@@ -191,6 +191,7 @@ class TemperatureLimitAssessment:
     limit_temperature_c: float
     exceeded: bool
     first_exceedance_time_s: float | None
+    final_recovery_time_s: float | None
     time_above_limit_s: float
     exposure_fraction: float
     peak_temperature_c: float
@@ -254,6 +255,7 @@ class ThermalSimulation:
 
         _temperature_k(limit_temperature_c, "limit_temperature_c")
         first_exceedance_time_s: float | None = None
+        last_recovery_time_s: float | None = None
         time_above_limit_s = 0.0
         if self.temperature_c[0] > limit_temperature_c:
             first_exceedance_time_s = self.time_s[0]
@@ -284,14 +286,22 @@ class ThermalSimulation:
                     first_exceedance_time_s = crossing_time_s
             else:
                 time_above_limit_s += crossing_time_s - start_time_s
+                last_recovery_time_s = crossing_time_s
                 if first_exceedance_time_s is None:
                     first_exceedance_time_s = start_time_s
 
         peak_temperature_c = self.peak_temperature_c
+        final_recovery_time_s = (
+            last_recovery_time_s
+            if first_exceedance_time_s is not None
+            and self.temperature_c[-1] <= limit_temperature_c
+            else None
+        )
         return TemperatureLimitAssessment(
             limit_temperature_c=limit_temperature_c,
             exceeded=first_exceedance_time_s is not None,
             first_exceedance_time_s=first_exceedance_time_s,
+            final_recovery_time_s=final_recovery_time_s,
             time_above_limit_s=time_above_limit_s,
             exposure_fraction=time_above_limit_s / self.duration_s,
             peak_temperature_c=peak_temperature_c,
@@ -965,6 +975,7 @@ def write_temperature_limit_csv(
         "limit_temperature_c",
         "exceeded",
         "first_exceedance_time_s",
+        "final_recovery_time_s",
         "time_above_limit_s",
         "exposure_fraction",
         "peak_temperature_c",
@@ -984,6 +995,11 @@ def write_temperature_limit_csv(
                         ""
                         if assessment.first_exceedance_time_s is None
                         else format(assessment.first_exceedance_time_s, ".12g")
+                    ),
+                    "final_recovery_time_s": (
+                        ""
+                        if assessment.final_recovery_time_s is None
+                        else format(assessment.final_recovery_time_s, ".12g")
                     ),
                     "time_above_limit_s": format(
                         assessment.time_above_limit_s, ".12g"
@@ -1263,6 +1279,12 @@ def main(argv: Sequence[str] | None = None) -> int:
             f"{status}"
         )
         print(f"  First exceedance: {first_exceedance}")
+        final_recovery = (
+            "not recovered"
+            if assessment.final_recovery_time_s is None
+            else f"{assessment.final_recovery_time_s:.6g} s"
+        )
+        print(f"  Final recovery: {final_recovery}")
         print(
             "  Exposure: "
             f"{assessment.time_above_limit_s:.6g} s "

--- a/tests/test_lumped_cell_thermal.py
+++ b/tests/test_lumped_cell_thermal.py
@@ -46,6 +46,7 @@ class LumpedCellThermalTests(unittest.TestCase):
                 limit_temperature_c=25.0,
                 exceeded=True,
                 first_exceedance_time_s=5.0,
+                final_recovery_time_s=None,
                 time_above_limit_s=15.0,
                 exposure_fraction=0.75,
                 peak_temperature_c=40.0,
@@ -70,8 +71,29 @@ class LumpedCellThermalTests(unittest.TestCase):
         assessment = result.assess_temperature_limit(25.0)
 
         self.assertEqual(assessment.first_exceedance_time_s, 5.0)
+        self.assertEqual(assessment.final_recovery_time_s, 15.0)
         self.assertEqual(assessment.time_above_limit_s, 10.0)
         self.assertEqual(assessment.exposure_fraction, 0.5)
+
+    def test_temperature_limit_reports_recovery_after_last_excursion(self):
+        result = simulate_lumped_temperature(
+            [0.0, 0.0, 0.0, 0.0],
+            LumpedThermalSpec(
+                mass_kg=1.0,
+                specific_heat_j_per_kg_k=1.0,
+                resistance_ohm=0.0,
+                heat_transfer_w_per_k=0.0,
+                initial_temperature_c=20.0,
+                time_step_s=10.0,
+            ),
+            external_heats_w=(1.0, -1.0, 1.0, -1.0),
+        )
+
+        assessment = result.assess_temperature_limit(25.0)
+
+        self.assertEqual(assessment.first_exceedance_time_s, 5.0)
+        self.assertEqual(assessment.final_recovery_time_s, 35.0)
+        self.assertEqual(assessment.time_above_limit_s, 20.0)
 
     def test_temperature_limit_uses_variable_interval_durations(self):
         result = simulate_lumped_temperature(
@@ -98,6 +120,7 @@ class LumpedCellThermalTests(unittest.TestCase):
 
         self.assertFalse(assessment.exceeded)
         self.assertIsNone(assessment.first_exceedance_time_s)
+        self.assertIsNone(assessment.final_recovery_time_s)
         self.assertEqual(assessment.time_above_limit_s, 0.0)
         self.assertEqual(assessment.margin_to_limit_c, 0.0)
 
@@ -119,6 +142,7 @@ class LumpedCellThermalTests(unittest.TestCase):
 
         self.assertTrue(assessment.exceeded)
         self.assertEqual(assessment.first_exceedance_time_s, 0.0)
+        self.assertEqual(assessment.final_recovery_time_s, 5.0)
         self.assertEqual(assessment.time_above_limit_s, 5.0)
 
     def test_temperature_limit_rejects_nonphysical_values(self):
@@ -142,7 +166,9 @@ class LumpedCellThermalTests(unittest.TestCase):
 
         self.assertEqual([row["exceeded"] for row in rows], ["true", "false"])
         self.assertEqual(float(rows[0]["first_exceedance_time_s"]), 5.0)
+        self.assertEqual(rows[0]["final_recovery_time_s"], "")
         self.assertEqual(rows[1]["first_exceedance_time_s"], "")
+        self.assertEqual(rows[1]["final_recovery_time_s"], "")
         self.assertEqual(float(rows[1]["margin_to_limit_c"]), 5.0)
 
     def test_temperature_limit_report_requires_assessments(self):


### PR DESCRIPTION
## Summary
- add a final, interpolated recovery time to temperature-limit assessments
- include recovery time in CSV and CLI summaries
- cover cooling, repeated excursions, ongoing excursions, and no excursions

## Validation
- python -m unittest discover -s tests -q (78 tests)
- CLI recovery smoke test