### PR TITLE
Harden profile CSV header parsing

### DIFF
--- a/models/lumped_cell_thermal.py
+++ b/models/lumped_cell_thermal.py
@@ -532,6 +532,7 @@ def load_current_profile(path: Path) -> CurrentProfile:
 
     with path.open("r", encoding="utf-8", newline="") as profile_file:
         reader = csv.DictReader(profile_file)
+        raw_fieldnames = reader.fieldnames or []
         required_headers = ["time_s", "current_a"]
         optional_headers = [
             "duration_s",
@@ -541,7 +542,10 @@ def load_current_profile(path: Path) -> CurrentProfile:
             "external_heat_w",
             "heat_transfer_w_per_k",
         ]
-        fieldnames = reader.fieldnames or []
+        fieldnames = [fieldname.strip().lstrip("\ufeff") for fieldname in raw_fieldnames]
+        if any(fieldname == "" for fieldname in fieldnames):
+            raise ValueError("profile CSV header must contain non-empty column names")
+        reader.fieldnames = fieldnames
         selected_optional_headers = [
             header for header in optional_headers if header in fieldnames[2:]
         ]

--- a/tests/test_lumped_cell_thermal.py
+++ b/tests/test_lumped_cell_thermal.py
@@ -778,6 +778,30 @@ class LumpedCellThermalTests(unittest.TestCase):
         self.assertEqual(profile.ambient_temperature_c, (35.0, 35.0))
         self.assertEqual(profile.heat_transfer_w_per_k, (0.6, 4.0))
 
+    def test_loads_csv_with_bom_and_spaced_headers(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "profile.csv"
+            path.write_text(
+                "\ufefftime_s, current_a , duration_s \n"
+                "0,0,60\n"
+                "60,10,60\n",
+                encoding="utf-8",
+            )
+            profile = load_current_profile(path)
+        self.assertEqual(profile.time_s, (0.0, 60.0))
+        self.assertEqual(profile.current_a, (0.0, 10.0))
+        self.assertEqual(profile.interval_duration_s, (60.0, 60.0))
+
+    def test_rejects_empty_csv_headers(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "profile.csv"
+            path.write_text("time_s,,current_a\n0,0,1\n", encoding="utf-8")
+            with self.assertRaisesRegex(
+                ValueError,
+                "header must contain non-empty",
+            ):
+                load_current_profile(path)
+
     def test_loads_profile_with_signed_external_heat(self):
         with tempfile.TemporaryDirectory() as directory:
             path = Path(directory) / "profile.csv"


### PR DESCRIPTION
## Summary
- Normalize CSV header field names (trim whitespace/BOM) before validation.
- Reject empty header names explicitly.
- Add tests for BOM/spaced headers and empty headers.
