### PR TITLE
Handle commented and blank lines in CSV profiles

### DIFF
--- a/models/lumped_cell_thermal.py
+++ b/models/lumped_cell_thermal.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import io
 import csv
 import math
 from dataclasses import dataclass
@@ -531,7 +532,14 @@ def load_current_profile(path: Path) -> CurrentProfile:
     """Load piecewise-constant electrical and thermal profile intervals."""
 
     with path.open("r", encoding="utf-8", newline="") as profile_file:
-        reader = csv.DictReader(profile_file)
+        cleaned_profile_lines: list[tuple[int, str]] = []
+        for line_number, line in enumerate(profile_file, start=1):
+            if not line.strip():
+                continue
+            if line.lstrip().startswith("#"):
+                continue
+            cleaned_profile_lines.append((line_number, line))
+        reader = csv.DictReader(io.StringIO("".join(line for _, line in cleaned_profile_lines)))
         required_headers = ["time_s", "current_a"]
         optional_headers = [
             "duration_s",
@@ -565,6 +573,7 @@ def load_current_profile(path: Path) -> CurrentProfile:
         has_external_heat = "external_heat_w" in fieldnames
         has_heat_transfer = "heat_transfer_w_per_k" in fieldnames
         rows = list(reader)
+        row_line_numbers = [line_number for line_number, _ in cleaned_profile_lines[1:]]
 
     if not rows:
         raise ValueError("profile CSV must contain at least one interval")
@@ -579,7 +588,7 @@ def load_current_profile(path: Path) -> CurrentProfile:
     entropic_coefficients: list[float] = []
     external_heats: list[float] = []
     heat_transfers: list[float] = []
-    for line_number, row in enumerate(rows, start=2):
+    for line_number, row in zip(row_line_numbers, rows):
         try:
             time_s = float(row["time_s"])
             current_a = float(row["current_a"])

--- a/tests/test_lumped_cell_thermal.py
+++ b/tests/test_lumped_cell_thermal.py
@@ -698,6 +698,25 @@ class LumpedCellThermalTests(unittest.TestCase):
         self.assertEqual(profile.time_step_s, 60.0)
         self.assertEqual(profile.interval_duration_s, (60.0, 60.0, 60.0))
 
+    def test_loads_csv_with_comments_and_blank_lines(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "profile.csv"
+            path.write_text(
+                "# profile for discharge profile\n"
+                "\n"
+                "time_s,current_a\n"
+                "0,0\n"
+                "# step 2\n"
+                "30,10\n"
+                "\n"
+                "60,-5\n",
+                encoding="utf-8",
+            )
+            profile = load_current_profile(path)
+        self.assertEqual(profile.time_s, (0.0, 30.0, 60.0))
+        self.assertEqual(profile.current_a, (0.0, 10.0, -5.0))
+        self.assertEqual(profile.interval_duration_s, (30.0, 30.0, 30.0))
+
     def test_loads_explicit_nonuniform_interval_durations(self):
         with tempfile.TemporaryDirectory() as directory:
             path = Path(directory) / "profile.csv"


### PR DESCRIPTION
## Summary
- Preprocess profile CSV files to skip comment lines and blank lines before parsing.
- Preserve original line numbers for clearer parse errors.
- Add regression coverage for comment+blank line handling in profile loader tests.
