### PR TITLE
docs: add scope and citation guidance

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,16 @@
+cff-version: 1.2.0
+message: "If you use these notes or models in research or teaching, please cite this repository."
+type: software
+title: "Battery Thermal Modeling Notes"
+authors:
+  - family-names: Khan
+    given-names: Mohammad Rezwan
+    orcid: "https://orcid.org/0000-0002-1532-0598"
+repository-code: "https://github.com/mohammadrezwankhan/battery-thermal-modeling-notes"
+url: "https://github.com/mohammadrezwankhan/battery-thermal-modeling-notes"
+license: MIT
+keywords:
+  - battery thermal management
+  - BTMS
+  - heat generation
+  - thermal model validation

--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@
 Research-backed notes and reproducible examples for battery thermal behavior,
 BTMS design thinking, and validation assumptions.
 
+## Documentation Map
+
+- [Starter notes](#starter-notes) for the source-backed reading path.
+- [Executable reference](#run-the-executable-reference) for a dependency-free model run.
+- [Model assumptions and limitations](models/README.md) before reusing parameters or outputs.
+- [Contribution entry points](#contribution-entry-points) for focused improvements.
+- [Citation metadata](CITATION.cff) and [license](LICENSE) for shared work.
+
 ## Focus Areas
 
 - Battery heat generation and thermal pathways.
@@ -87,6 +95,7 @@ figures/
 references/
 README.md
 CONTRIBUTING.md
+CITATION.cff
 LICENSE
 ```
 
@@ -146,6 +155,21 @@ external heat sources and heat-transfer coefficients, explicit nonuniform
 interval durations, optional diffuse-gray radiation, and interval-level CSV
 results. Repeatable temperature limits add first-crossing, exposure-duration,
 and peak-margin summaries without changing the thermal integration.
+
+## Scope and Limitations
+
+This repository is a research and teaching reference. Its notes, templates, and
+executable examples do not certify thermal runaway behavior, cell safety, BTMS
+performance, product compliance, or an operational temperature limit. Replace
+illustrative parameters with traceable project data and obtain independent
+engineering, safety, and standards review before making a design or field
+decision.
+
+## Citation
+
+If these notes or models support a paper, report, lecture, or design review, use
+the machine-readable [CITATION.cff](CITATION.cff) metadata and cite the specific
+note, model version, data source, and assumptions used.
 
 ## Contribution Entry Points
 


### PR DESCRIPTION
## Summary

- add a documentation map for starter notes, executable examples, assumptions, contributions, citation, and licensing
- make the research/teaching boundary explicit for thermal safety, runaway, and operational-limit claims
- add validated `CITATION.cff` metadata

## Validation

- `python -m unittest discover -s tests -v` — 84 passed
- `cffconvert --validate` — valid
- internal Markdown paths checked
- `git diff --check`
